### PR TITLE
Support negotiation out-of-band and custom channel IDs

### DIFF
--- a/aiortc/rtcpeerconnection.py
+++ b/aiortc/rtcpeerconnection.py
@@ -441,7 +441,7 @@ class RTCPeerConnection(EventEmitter):
         return wrap_session_description(description)
 
     def createDataChannel(self, label, maxPacketLifeTime=None, maxRetransmits=None,
-                          ordered=True, protocol=''):
+                          ordered=True, protocol='', negotiated=False, id=None):
         """
         Create a data channel with the given label.
 
@@ -454,9 +454,11 @@ class RTCPeerConnection(EventEmitter):
             self.__createSctpTransport()
 
         parameters = RTCDataChannelParameters(
+            id=id,
             label=label,
             maxPacketLifeTime=maxPacketLifeTime,
             maxRetransmits=maxRetransmits,
+            negotiated=negotiated,
             ordered=ordered,
             protocol=protocol)
         return RTCDataChannel(self.__sctp, parameters)


### PR DESCRIPTION
Hello,

this PR implements #150. I propose to change initializer of RTCDataChannel, moving argument id to RTCDataChannelParameters as it was not document anyway and it makes more sense to have it there.

This handles two new cases: negotiation out-of-band when we need to provide an id and providing custom id while keeping negotiation in-band.