### PR TITLE
SSL_CTX_set_ecdh_auto when OpenSSL = 1.0.2

### DIFF
--- a/aiortc/rtcdtlstransport.py
+++ b/aiortc/rtcdtlstransport.py
@@ -137,11 +137,16 @@ def create_ssl_context(certificate):
 
     # specify an EDCH group for ECDHE ciphers, otherwise OpenSSL < 1.1.0
     # cannot negotiate them in server mode
-    if lib.OpenSSL_version_num() < 0x10100000:  # pragma: no cover
-        ecdh = lib.EC_KEY_new_by_curve_name(lib.NID_X9_62_prime256v1)
-        lib.SSL_CTX_set_options(ctx, lib.SSL_OP_SINGLE_ECDH_USE)
-        lib.SSL_CTX_set_tmp_ecdh(ctx, ecdh)
-        lib.EC_KEY_free(ecdh)
+    if lib.OpenSSL_version_num() < 0x101000000:
+        if lib.OpenSSL_version_num() >= 0x10002000:
+            logger.debug('OpenSSL version is 1.0.2, using AUTO ECDH')
+            lib.SSL_CTX_set_ecdh_auto(ctx, 1)
+        else:
+            logger.debug('OpenSSL version is < 1.0.2, using MANUAL ECDH')
+            ecdh = lib.EC_KEY_new_by_curve_name(lib.NID_X9_62_prime256v1)
+            lib.SSL_CTX_set_options(ctx, lib.SSL_OP_SINGLE_ECDH_USE)
+            lib.SSL_CTX_set_tmp_ecdh(ctx, ecdh)
+            lib.EC_KEY_free(ecdh)
 
     return ctx
 


### PR DESCRIPTION
I tried to test aiortc on a box with openssl 1.0.2g, then I got the following error.

>   File "cli.py", line 272, in call_peer
>     self._channel = self._pc.createDataChannel('data')
>   File "/home/nvidia/projects/aiortc/aiortc/rtcpeerconnection.py", line 454, in createDataChannel
>     self.__createSctpTransport()
>   File "/home/nvidia/projects/aiortc/aiortc/rtcpeerconnection.py", line 827, in __createSctpTransport
>     self.__sctp = RTCSctpTransport(self.__createDtlsTransport())
>   File "/home/nvidia/projects/aiortc/aiortc/rtcpeerconnection.py", line 824, in __createDtlsTransport
>     return RTCDtlsTransport(iceTransport, self.__certificates)
>   File "/home/nvidia/projects/aiortc/aiortc/rtcdtlstransport.py", line 337, in __init__
>     self.__ctx = create_ssl_context(certificate)
>   File "/home/nvidia/projects/aiortc/aiortc/rtcdtlstransport.py", line 141, in create_ssl_context
>     ecdh = lib.EC_KEY_new_by_curve_name(lib.NID_X9_62_prime256v1)
> AttributeError: module 'lib' has no attribute 'NID_X9_62_prime256v1'

This box is a NVIDIA's Tegra(Jetson TX2) machine based on Ubuntu 16.04.4. I could compile and install OpenSSL 1.1, but which is not only complicated, but already has too many dependencies to any programs built on this.

So, I am not sure about these DTLS details, but learned it is recommended to call ecdh auto function for a server to choose the most appropriate curve for a client, if OpenSSL version is 1.0.2.
https://www.openssl.org/docs/man1.0.2/man3/SSL_CTX_set_ecdh_auto.html

I confirmed aiortc works fine on the box with this fix. But again, I am not sure, so please take this as a question with code.