### PR TITLE
[dtls] call SSL_CTX_set_ecdh_auto for OpenSSL 1.0.2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,8 +22,13 @@ matrix:
   - language: generic
     os: osx
   - python: "3.5"
+  - env: CRYPTOGRAPHY_NO_BINARY=1
+    dist: trusty
+    python: "3.5"
   - python: "3.6"
   - python: "3.7"
+  - env: CRYPTOGRAPHY_NO_BINARY=1
+    python: "3.7"
   - env: BUILD=sdist
     install: true
     python: "3.6"

--- a/.travis/install
+++ b/.travis/install
@@ -22,4 +22,10 @@ if [ "$(uname -s)" != "Darwin" ]; then
 fi
 
 pip3 install -U setuptools
+
+# force cryptography to use the system's OpenSSL if requested
+if [ -n "$CRYPTOGRAPHY_NO_BINARY" ]; then
+    pip3 install cryptography --no-binary cryptography
+fi
+
 pip3 install coverage flake8 isort opencv-python

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,16 @@ Changelog
 
 .. currentmodule:: aiortc
 
+0.9.21
+------
+
+*under development*
+
+DTLS
+....
+
+  * Call SSL_CTX_set_ecdh_auto for OpenSSL 1.0.2.
+
 0.9.20
 ------
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -1,6 +1,9 @@
 import asyncio
 import logging
 import os
+import sys
+
+from cryptography.hazmat.backends.openssl.backend import backend
 
 from aiortc.rtcdtlstransport import RTCCertificate, RTCDtlsTransport
 
@@ -99,3 +102,6 @@ def run(coro):
 
 if os.environ.get('AIORTC_DEBUG'):
     logging.basicConfig(level=logging.DEBUG)
+
+if os.environ.get('TRAVIS'):
+    sys.stderr.write(backend.openssl_version_text() + '\n')


### PR DESCRIPTION
To ensure it works as expected, add some Travis profiles:

- using Xenial's OpenSSL 1.0.2g
- using Trusty's OpenSSL 1.0.1f