### PR TITLE
msid workaround

### DIFF
--- a/aiortc/rtcpeerconnection.py
+++ b/aiortc/rtcpeerconnection.py
@@ -454,7 +454,7 @@ class RTCPeerConnection(EventEmitter):
         return wrap_session_description(description)
 
     def createDataChannel(self, label, maxPacketLifeTime=None, maxRetransmits=None,
-                          ordered=True, protocol=''):
+                          ordered=True, protocol='', negotiated=False, id=None):
         """
         Create a data channel with the given label.
 
@@ -467,9 +467,11 @@ class RTCPeerConnection(EventEmitter):
             self.__createSctpTransport()
 
         parameters = RTCDataChannelParameters(
+            id=id,
             label=label,
             maxPacketLifeTime=maxPacketLifeTime,
             maxRetransmits=maxRetransmits,
+            negotiated=negotiated,
             ordered=ordered,
             protocol=protocol)
         return RTCDataChannel(self.__sctp, parameters)

--- a/aiortc/rtcrtptransceiver.py
+++ b/aiortc/rtcrtptransceiver.py
@@ -1,9 +1,31 @@
 import logging
+import uuid
 
 from aiortc.codecs import get_capabilities
 from aiortc.sdp import DIRECTIONS
 
 logger = logging.getLogger('rtp')
+
+class MediaStream:
+
+    """
+    A MediaStream is used to group several MediaStreamTracks 
+    to allow various track operations without a renigotiation.
+
+    9. Media Stream API Extensions for Network Use
+    WebRTC 1.0: Real-time Communication Between Browsers
+
+    4. Media Stream API
+    Media Capture And Streams
+    """
+
+    def __init__(self):
+        self.__id = str(uuid.uuid4())
+
+    @property
+    def id(self):
+        return self.__id
+    
 
 
 class RTCRtpTransceiver:
@@ -21,6 +43,7 @@ class RTCRtpTransceiver:
         self.__receiver = receiver
         self.__sender = sender
         self.__stopped = False
+        self.__stream = MediaStream()
 
         self._currentDirection = None
         self._offerDirection = None
@@ -77,6 +100,11 @@ class RTCRtpTransceiver:
     @property
     def stopped(self):
         return self.__stopped
+
+    @property
+    def stream(self):
+        return self.__stream
+    
 
     def setCodecPreferences(self, codecs):
         """

--- a/examples/server/client.js
+++ b/examples/server/client.js
@@ -10,6 +10,9 @@ var pc = null;
 // data channel
 var dc = null, dcInterval = null;
 
+//
+var streamsReceived = 0
+
 function createPeerConnection() {
     var config = {
         sdpSemantics: 'unified-plan'
@@ -40,7 +43,7 @@ function createPeerConnection() {
     // connect audio / video
     pc.addEventListener('track', function(evt) {
         if (evt.track.kind == 'video')
-            document.getElementById('video').srcObject = evt.streams[0];
+            document.getElementById('video' + (streamsReceived++).toString()).srcObject = evt.streams[0];
         else
             document.getElementById('audio').srcObject = evt.streams[0];
     });
@@ -170,6 +173,8 @@ function start() {
             stream.getTracks().forEach(function(track) {
                 pc.addTrack(track, stream);
             });
+            // add one more receive only video transceiver
+            pc.addTransceiver('video', {'direction': 'recvonly'})
             return negotiate();
         }, function(err) {
             alert('Could not acquire media: ' + err);

--- a/examples/server/index.html
+++ b/examples/server/index.html
@@ -93,7 +93,8 @@
     <h2>Media</h2>
 
     <audio id="audio" autoplay="true"></audio>
-    <video id="video" autoplay="true"></video>
+    <video id="video0" autoplay="true"></video>
+    <video id="video1" autoplay="true"></video>
 </div>
 
 <h2>Data channel</h2>

--- a/examples/server/server.py
+++ b/examples/server/server.py
@@ -135,6 +135,8 @@ async def offer(request):
         elif track.kind == 'video':
             local_video = VideoTransformTrack(track, transform=params['video_transform'])
             pc.addTrack(local_video)
+            # create another track without transformation
+            pc.addTrack(VideoTransformTrack(track, transform=None))
 
         @track.on('ended')
         async def on_ended():


### PR DESCRIPTION
I have tried to send multiple video tracks over a single RTCPeerConnection. A video element was shown successfully, but for some reasons, the first track was played on all the video elements on Chrome 73 on Mac.

Then I found that msid-id is a sender's stream id, and which is an uuid of a RTCPeerConnection instance. So, it means that all the tracks share the same stream id.

According to [WebRTC MediaStream Identification in the Session Description Protocol draft-ietf-mmusic-msid-17](https://tools.ietf.org/html/draft-ietf-mmusic-msid-17#section-2), the former part of a msid, called msid-id, is explained as follows.

> The value of the "msid-id" field in the msid consists of the "id"
> attribute of a MediaStream, as defined in the MediaStream's WebIDL
> specification.  The special value "-" indicates "no MediaStream".

The MediaStream class seems to be somewhat unclear, but at least, it represents a source of a media stream that contains multiple MediaStreamTracks.

By simply introducing a MediaStream class that has only one attribute, id, msid becomes more compliant, and all the video element play their own streams.

For the reference, I have updated the server example as well.

As the title suggests, I think this is a work around. According to those docs, MediaStream has many duties.