### PR TITLE
Add playsinline to video elems for ios compatibility

### DIFF
--- a/examples/server/index.html
+++ b/examples/server/index.html
@@ -93,7 +93,7 @@
     <h2>Media</h2>
 
     <audio id="audio" autoplay="true"></audio>
-    <video id="video" autoplay="true"></video>
+    <video id="video" autoplay="true" playsinline="true"></video>
 </div>
 
 <h2>Data channel</h2>

--- a/examples/webcam/index.html
+++ b/examples/webcam/index.html
@@ -26,7 +26,7 @@
     <h2>Media</h2>
 
     <audio id="audio" autoplay="true"></audio>
-    <video id="video" autoplay="true"></video>
+    <video id="video" autoplay="true" playsinline="true"></video>
 </div>
 
 <script src="client.js"></script>


### PR DESCRIPTION
This fixes compatibility of html examples with iOS Safari.
Without the playsinline attribute, webkit browsers won't play the video stream, and it will remain black.
