### PR TITLE
Replace deprecated EventEmitter with AsyncIOEventEmitter class

### DIFF
--- a/aiortc/mediastreams.py
+++ b/aiortc/mediastreams.py
@@ -4,7 +4,7 @@ import time
 import uuid
 
 from av import AudioFrame, VideoFrame
-from pyee import EventEmitter
+from pyee import AsyncIOEventEmitter
 
 AUDIO_PTIME = 0.020  # 20ms audio packetization
 VIDEO_CLOCK_RATE = 90000
@@ -22,7 +22,7 @@ class MediaStreamError(Exception):
     pass
 
 
-class MediaStreamTrack(EventEmitter):
+class MediaStreamTrack(AsyncIOEventEmitter):
     """
     A single media track within a stream.
 

--- a/aiortc/rtcdatachannel.py
+++ b/aiortc/rtcdatachannel.py
@@ -1,14 +1,14 @@
 import logging
 
 import attr
-from pyee import EventEmitter
+from pyee import AsyncIOEventEmitter
 
 from .exceptions import InvalidStateError
 
 logger = logging.getLogger("datachannel")
 
 
-class RTCDataChannel(EventEmitter):
+class RTCDataChannel(AsyncIOEventEmitter):
     """
     The :class:`RTCDataChannel` interface represents a network channel which
     can be used for bidirectional peer-to-peer transfers of arbitrary data.

--- a/aiortc/rtcdtlstransport.py
+++ b/aiortc/rtcdtlstransport.py
@@ -18,7 +18,7 @@ from cryptography.hazmat.primitives.serialization import (
     PrivateFormat,
 )
 from OpenSSL import crypto
-from pyee import EventEmitter
+from pyee import AsyncIOEventEmitter
 from pylibsrtp import Policy, Session
 
 from . import clock, rtp
@@ -339,7 +339,7 @@ class RtpRouter:
                 d.pop(k)
 
 
-class RTCDtlsTransport(EventEmitter):
+class RTCDtlsTransport(AsyncIOEventEmitter):
     """
     The :class:`RTCDtlsTransport` object includes information relating to
     Datagram Transport Layer Security (DTLS) transport.

--- a/aiortc/rtcicetransport.py
+++ b/aiortc/rtcicetransport.py
@@ -4,7 +4,7 @@ import re
 
 import attr
 from aioice import Candidate, Connection
-from pyee import EventEmitter
+from pyee import AsyncIOEventEmitter
 
 from .exceptions import InvalidStateError
 from .rtcconfiguration import RTCIceServer
@@ -140,7 +140,7 @@ def parse_stun_turn_uri(uri):
     return match
 
 
-class RTCIceGatherer(EventEmitter):
+class RTCIceGatherer(AsyncIOEventEmitter):
     """
     The :class:`RTCIceGatherer` interface gathers local host, server reflexive
     and relay candidates, as well as enabling the retrieval of local
@@ -220,7 +220,7 @@ class RTCIceParameters:
     iceLite = attr.ib(default=False)
 
 
-class RTCIceTransport(EventEmitter):
+class RTCIceTransport(AsyncIOEventEmitter):
     """
     The :class:`RTCIceTransport` interface allows an application access to
     information about the Interactive Connectivity Establishment (ICE)

--- a/aiortc/rtcpeerconnection.py
+++ b/aiortc/rtcpeerconnection.py
@@ -3,7 +3,7 @@ import copy
 import uuid
 from collections import OrderedDict
 
-from pyee import EventEmitter
+from pyee import AsyncIOEventEmitter
 
 from . import clock, rtp, sdp
 from .codecs import CODECS, HEADER_EXTENSIONS, is_rtx
@@ -233,7 +233,7 @@ def wrap_session_description(session_description: sdp.SessionDescription):
         )
 
 
-class RTCPeerConnection(EventEmitter):
+class RTCPeerConnection(AsyncIOEventEmitter):
     """
     The :class:`RTCPeerConnection` interface represents a WebRTC connection
     between the local computer and a remote peer.

--- a/aiortc/rtcsctptransport.py
+++ b/aiortc/rtcsctptransport.py
@@ -9,7 +9,7 @@ from collections import deque
 from struct import pack, unpack_from
 
 import attr
-from pyee import EventEmitter
+from pyee import AsyncIOEventEmitter
 
 from .exceptions import InvalidStateError
 from .rtcdatachannel import RTCDataChannel, RTCDataChannelParameters
@@ -574,7 +574,7 @@ class RTCSctpCapabilities:
     """
 
 
-class RTCSctpTransport(EventEmitter):
+class RTCSctpTransport(AsyncIOEventEmitter):
     """
     The :class:`RTCSctpTransport` interface includes information relating to
     Stream Control Transmission Protocol (SCTP) transport.

--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ install_requires = [
     'cffi>=1.0.0',
     'crc32c',
     'cryptography>=2.2',
-    'pyee',
+    'pyee>=6.0.0',
     'pylibsrtp>=0.5.6',
     'pyopenssl',
 ]


### PR DESCRIPTION
EventEmitter is deprecated and will be removed in a future. Replace all usage of EventEmitter with AsyncIOEventEmitter class.