### PR TITLE
Set correct predicate that skip av module in case when READTHEDOCS set

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -25,7 +25,7 @@ install_requires = [
 
 if os.environ.get('READTHEDOCS') == 'True':
     cffi_modules = []
-    install_requires = list(filter(lambda x: x != 'av', install_requires))
+    install_requires = list(filter(lambda x: not x.startswith('av'), install_requires))
 
 setuptools.setup(
     name='aiortc',


### PR DESCRIPTION
Looks like when requirements for "av" module was updated, predicate for install_requires filter wasn't.