### PR TITLE
Support alsa hardware output in MediaRecorder

### DIFF
--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -325,7 +325,7 @@ class MediaRecorder:
         :param track: A :class:`aiortc.MediaStreamTrack`.
         """
         if track.kind == "audio":
-            if self.__container.format.name == "wav":
+            if self.__container.format.name in ("wav", "alsa"):
                 codec_name = "pcm_s16le"
             elif self.__container.format.name == "mp3":
                 codec_name = "mp3"

--- a/tests/test_contrib_media.py
+++ b/tests/test_contrib_media.py
@@ -232,19 +232,6 @@ class MediaRecorderTest(MediaTestCase):
 
         run(recorder.stop())
 
-    def test_audio_alsa(self):
-        """Test if MediaRecorder passes proper codec when using alsa output."""
-        recorder = MediaRecorder("null", format="alsa")
-        recorder.addTrack(AudioStreamTrack())
-        run(recorder.start())
-        try:
-            run(recorder.stop())
-        except NotImplementedError as e:
-            if "sample format 0x15002 is not supported" in str(e):
-                self.fail("Invalid codec to alsa format")
-            else:
-                raise e
-
     def test_audio_and_video(self):
         path = self.temporary_path("test.mp4")
         recorder = MediaRecorder(path)

--- a/tests/test_contrib_media.py
+++ b/tests/test_contrib_media.py
@@ -234,7 +234,7 @@ class MediaRecorderTest(MediaTestCase):
 
     def test_audio_alsa(self):
         """Test if MediaRecorder passes proper codec when using alsa output."""
-        recorder = MediaRecorder("default", format="alsa")
+        recorder = MediaRecorder("null", format="alsa")
         recorder.addTrack(AudioStreamTrack())
         run(recorder.start())
         try:

--- a/tests/test_contrib_media.py
+++ b/tests/test_contrib_media.py
@@ -232,6 +232,19 @@ class MediaRecorderTest(MediaTestCase):
 
         run(recorder.stop())
 
+    def test_audio_alsa(self):
+        """Test if MediaRecorder passes proper codec when using alsa output."""
+        recorder = MediaRecorder("default", format="alsa")
+        recorder.addTrack(AudioStreamTrack())
+        run(recorder.start())
+        try:
+            run(recorder.stop())
+        except NotImplementedError as e:
+            if "sample format 0x15002 is not supported" in str(e):
+                self.fail("Invalid codec to alsa format")
+            else:
+                raise e
+
     def test_audio_and_video(self):
         path = self.temporary_path("test.mp4")
         recorder = MediaRecorder(path)


### PR DESCRIPTION
This change allows for MediaRecorder to stream tracks to alsa hardware output.