### PR TITLE
Replace old-style string formatting with f-strings

### DIFF
--- a/src/aiortc/codecs/__init__.py
+++ b/src/aiortc/codecs/__init__.py
@@ -111,7 +111,7 @@ def depayload(codec: RTCRtpCodecParameters, payload: bytes) -> bytes:
 
 def get_capabilities(kind: str) -> RTCRtpCapabilities:
     if kind not in CODECS:
-        raise ValueError("cannot get capabilities for unknown media %s" % kind)
+        raise ValueError(f"cannot get capabilities for unknown media {kind}")
 
     codecs = []
     rtx_added = False
@@ -155,7 +155,7 @@ def get_decoder(codec: RTCRtpCodecParameters) -> Decoder:
     elif mimeType == "video/vp8":
         return Vp8Decoder()
     else:
-        raise ValueError("No decoder found for MIME type `%s`" % mimeType)
+        raise ValueError(f"No decoder found for MIME type `{mimeType}`")
 
 
 def get_encoder(codec: RTCRtpCodecParameters) -> Encoder:
@@ -172,7 +172,7 @@ def get_encoder(codec: RTCRtpCodecParameters) -> Encoder:
     elif mimeType == "video/vp8":
         return Vp8Encoder()
     else:
-        raise ValueError("No encoder found for MIME type `%s`" % mimeType)
+        raise ValueError(f"No encoder found for MIME type `{mimeType}`")
 
 
 def is_rtx(codec: Union[RTCRtpCodecCapability, RTCRtpCodecParameters]) -> bool:

--- a/src/aiortc/codecs/h264.py
+++ b/src/aiortc/codecs/h264.py
@@ -40,7 +40,7 @@ class H264PayloadDescriptor:
         self.first_fragment = first_fragment
 
     def __repr__(self):
-        return "H264PayloadDescriptor(FF={})".format(self.first_fragment)
+        return f"H264PayloadDescriptor(FF={self.first_fragment})"
 
     @classmethod
     def parse(cls: Type[DESCRIPTOR_T], data: bytes) -> Tuple[DESCRIPTOR_T, bytes]:
@@ -92,7 +92,7 @@ class H264PayloadDescriptor:
 
             obj = cls(first_fragment=True)
         else:
-            raise ValueError("NAL unit type %d is not supported" % nal_type)
+            raise ValueError(f"NAL unit type {nal_type} is not supported")
 
         return obj, output
 

--- a/src/aiortc/codecs/vpx.py
+++ b/src/aiortc/codecs/vpx.py
@@ -84,10 +84,9 @@ class VpxPayloadDescriptor:
         return data
 
     def __repr__(self) -> str:
-        return "VpxPayloadDescriptor(S=%d, PID=%d, pic_id=%s)" % (
-            self.partition_start,
-            self.partition_id,
-            self.picture_id,
+        return (
+            f"VpxPayloadDescriptor(S={self.partition_start}, "
+            f"PID={self.partition_id}, pic_id={self.picture_id})"
         )
 
     @classmethod

--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -286,7 +286,7 @@ class MediaPlayer:
             self.__container = None
 
     def __log_debug(self, msg, *args):
-        logger.debug("player(%s) " + msg, self.__container.name, *args)
+        logger.debug(f"player(%s) {msg}", self.__container.name, *args)
 
 
 class MediaRecorderContext:

--- a/src/aiortc/contrib/signaling.py
+++ b/src/aiortc/contrib/signaling.py
@@ -83,7 +83,7 @@ class ApprtcSignaling:
             )
         )
 
-        print("AppRTC room is %(room_id)s %(room_link)s" % params)
+        print(f"AppRTC room is {params['room_id']} {params['room_link']}")
 
         return params
 

--- a/src/aiortc/rtcdatachannel.py
+++ b/src/aiortc/rtcdatachannel.py
@@ -181,7 +181,7 @@ class RTCDataChannel(AsyncIOEventEmitter):
             raise InvalidStateError
 
         if not isinstance(data, (str, bytes)):
-            raise ValueError("Cannot send unsupported data type: %s" % type(data))
+            raise ValueError(f"Cannot send unsupported data type: {type(data)}")
 
         self.transport._data_channel_send(self, data)
 
@@ -199,7 +199,7 @@ class RTCDataChannel(AsyncIOEventEmitter):
 
     def _setReadyState(self, state: str) -> None:
         if state != self.__readyState:
-            self.__log_debug("- %s -> %s", self.__readyState, state)
+            self.__log_debug(f"- {self.__readyState} -> {state}")
             self.__readyState = state
 
             if state == "open":

--- a/src/aiortc/rtcdtlstransport.py
+++ b/src/aiortc/rtcdtlstransport.py
@@ -449,9 +449,9 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
                 if error == lib.SSL_ERROR_WANT_READ:
                     await self._recv_next()
                 else:
-                    self.__log_debug("x DTLS handshake failed (error %d)", error)
+                    self.__log_debug(f"x DTLS handshake failed (error {error})")
                     for info in get_error_queue():
-                        self.__log_debug("x %s", ":".join(info))
+                        self.__log_debug(f"x {':'.join(info)}")
                     self._set_state(State.FAILED)
                     return
         except ConnectionError:
@@ -561,7 +561,7 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
         try:
             packets = RtcpPacket.parse(data)
         except ValueError as exc:
-            self.__log_debug("x RTCP parsing failed: %s", exc)
+            self.__log_debug(f"x RTCP parsing failed: {exc}")
             return
 
         for packet in packets:
@@ -573,7 +573,7 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
         try:
             packet = RtpPacket.parse(data, self._rtp_header_extensions_map)
         except ValueError as exc:
-            self.__log_debug("x RTP parsing failed: %s", exc)
+            self.__log_debug(f"x RTP parsing failed: {exc}")
             return
 
         # route RTP packet
@@ -628,7 +628,7 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
                     data = self._rx_srtp.unprotect(data)
                     await self._handle_rtp_data(data, arrival_time_ms=arrival_time_ms)
             except pylibsrtp.Error as exc:
-                self.__log_debug("x SRTP unprotect failed: %s", exc)
+                self.__log_debug(f"x SRTP unprotect failed: {exc}")
 
     def _register_data_receiver(self, receiver) -> None:
         assert self._data_receiver is None
@@ -674,7 +674,7 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
 
     def _set_state(self, state: State) -> None:
         if state != self._state:
-            self.__log_debug("- %s -> %s", self._state, state)
+            self.__log_debug(f"- {self._state} -> {state}")
             self._state = state
             self.emit("statechange")
 

--- a/src/aiortc/rtcicetransport.py
+++ b/src/aiortc/rtcicetransport.py
@@ -345,7 +345,7 @@ class RTCIceTransport(AsyncIOEventEmitter):
 
     def __setState(self, state: str) -> None:
         if state != self.__state:
-            self.__log_debug("- %s -> %s", self.__state, state)
+            self.__log_debug(f"- {self.__state} -> {state}")
             self.__state = state
             self.emit("statechange")
 

--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -179,9 +179,7 @@ def create_media_description_for_sctp(
         media = sdp.MediaDescription(
             kind="application", port=DISCARD_PORT, profile="DTLS/SCTP", fmt=[sctp.port]
         )
-        media.sctpmap[sctp.port] = (
-            "webrtc-datachannel %d" % sctp._outbound_streams_count
-        )
+        media.sctpmap[sctp.port] = f"webrtc-datachannel {sctp._outbound_streams_count}"
     else:
         media = sdp.MediaDescription(
             kind="application",
@@ -208,7 +206,7 @@ def create_media_description_for_transceiver(
         fmt=[c.payloadType for c in transceiver._codecs],
     )
     media.direction = direction
-    media.msid = "%s %s" % (transceiver.sender._stream_id, transceiver.sender._track_id)
+    media.msid = f"{transceiver.sender._stream_id} {transceiver.sender._track_id}"
 
     media.rtp = RTCRtpParameters(
         codecs=transceiver._codecs,
@@ -274,7 +272,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
     def __init__(self, configuration: Optional[RTCConfiguration] = None) -> None:
         super().__init__()
         self.__certificates = [RTCCertificate.generateCertificate()]
-        self.__cname = "{%s}" % uuid.uuid4()
+        self.__cname = f"{uuid.uuid4()}"
         self.__configuration = configuration or RTCConfiguration()
         self.__iceTransports = set()  # type: Set[RTCIceTransport]
         self.__initialOfferer = None  # type: Optional[bool]
@@ -372,7 +370,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         # check state is valid
         self.__assertNotClosed()
         if track.kind not in ["audio", "video"]:
-            raise InternalError('Invalid track kind "%s"' % track.kind)
+            raise InternalError(f'Invalid track kind "{track.kind}"')
 
         # don't add track twice
         self.__assertTrackHasNoSender(track)
@@ -407,11 +405,11 @@ class RTCPeerConnection(AsyncIOEventEmitter):
             kind = trackOrKind
             track = None
         if kind not in ["audio", "video"]:
-            raise InternalError('Invalid track kind "%s"' % kind)
+            raise InternalError(f'Invalid track kind "{kind}"')
 
         # check direction
         if direction not in sdp.DIRECTIONS:
-            raise InternalError('Invalid direction "%s"' % direction)
+            raise InternalError(f'Invalid direction "{direction}"')
 
         # don't add track twice
         if track:
@@ -460,13 +458,13 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         self.__assertNotClosed()
         if self.signalingState not in ["have-remote-offer", "have-local-pranswer"]:
             raise InvalidStateError(
-                'Cannot create answer in signaling state "%s"' % self.signalingState
+                f'Cannot create answer in signaling state "{self.signalingState}"'
             )
 
         # create description
         ntp_seconds = clock.current_ntp_time() >> 32
         description = sdp.SessionDescription()
-        description.origin = "- %d %d IN IP4 0.0.0.0" % (ntp_seconds, ntp_seconds)
+        description.origin = f"- {ntp_seconds} {ntp_seconds} IN IP4 0.0.0.0"
         description.msid_semantic.append(
             sdp.GroupDescription(semantic="WMS", items=["*"])
         )
@@ -558,7 +556,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         # create description
         ntp_seconds = clock.current_ntp_time() >> 32
         description = sdp.SessionDescription()
-        description.origin = "- %d %d IN IP4 0.0.0.0" % (ntp_seconds, ntp_seconds)
+        description.origin = f"- {ntp_seconds} {ntp_seconds} IN IP4 0.0.0.0"
         description.msid_semantic.append(
             sdp.GroupDescription(semantic="WMS", items=["*"])
         )
@@ -1059,8 +1057,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
             if description.type == "offer":
                 if self.signalingState not in ["stable", "have-local-offer"]:
                     raise InvalidStateError(
-                        'Cannot handle offer in signaling state "%s"'
-                        % self.signalingState
+                        f'Cannot handle offer in signaling state "{self.signalingState}"'
                     )
             elif description.type == "answer":
                 if self.signalingState not in [
@@ -1068,15 +1065,13 @@ class RTCPeerConnection(AsyncIOEventEmitter):
                     "have-local-pranswer",
                 ]:
                     raise InvalidStateError(
-                        'Cannot handle answer in signaling state "%s"'
-                        % self.signalingState
+                        f'Cannot handle answer in signaling state "{self.signalingState}"'
                     )
         else:
             if description.type == "offer":
                 if self.signalingState not in ["stable", "have-remote-offer"]:
                     raise InvalidStateError(
-                        'Cannot handle offer in signaling state "%s"'
-                        % self.signalingState
+                        f'Cannot handle offer in signaling state "{self.signalingState}"'
                     )
             elif description.type == "answer":
                 if self.signalingState not in [
@@ -1084,8 +1079,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
                     "have-remote-pranswer",
                 ]:
                     raise InvalidStateError(
-                        'Cannot handle answer in signaling state "%s"'
-                        % self.signalingState
+                        f'Cannot handle answer in signaling state "{self.signalingState}"'
                     )
 
         for media in description.media:

--- a/src/aiortc/rtcrtpparameters.py
+++ b/src/aiortc/rtcrtpparameters.py
@@ -50,7 +50,7 @@ class RTCRtpCodecParameters:
         return self.mimeType.split("/")[1]
 
     def __str__(self):
-        s = "%s/%d" % (self.name, self.clockRate)
+        s = f"{self.name}/{self.clockRate}"
         if self.channels == 2:
             s += "/2"
         return s

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -376,7 +376,7 @@ class RTCRtpReceiver:
         self.__stop_decoder()
 
     async def _handle_rtcp_packet(self, packet: AnyRtcpPacket) -> None:
-        self.__log_debug("< %s", packet)
+        self.__log_debug(f"< {packet}")
 
         if isinstance(packet, RtcpSrPacket):
             self.__stats.add(
@@ -384,7 +384,7 @@ class RTCRtpReceiver:
                     # RTCStats
                     timestamp=clock.current_datetime(),
                     type="remote-outbound-rtp",
-                    id="remote-outbound-rtp_" + str(id(self)),
+                    id=f"remote-outbound-rtp_{id(self)}",
                     # RTCStreamStats
                     ssrc=packet.ssrc,
                     kind=self.__kind,
@@ -409,7 +409,7 @@ class RTCRtpReceiver:
         """
         Handle an incoming RTP packet.
         """
-        self.__log_debug("< %s", packet)
+        self.__log_debug(f"< {packet}")
 
         # feed bitrate estimator
         if self.__remote_bitrate_estimator is not None:
@@ -437,7 +437,7 @@ class RTCRtpReceiver:
         codec = self.__codecs.get(packet.payload_type)
         if codec is None:
             self.__log_debug(
-                "x RTP packet with unknown payload type %d", packet.payload_type
+                f"x RTP packet with unknown payload type {packet.payload_type}"
             )
             return
 
@@ -450,7 +450,7 @@ class RTCRtpReceiver:
         if is_rtx(codec):
             original_ssrc = self.__rtx_ssrc.get(packet.ssrc)
             if original_ssrc is None:
-                self.__log_debug("x RTX packet from unknown SSRC %d", packet.ssrc)
+                self.__log_debug(f"x RTX packet from unknown SSRC {packet.ssrc}")
                 return
 
             if len(packet.payload) < 2:
@@ -474,7 +474,7 @@ class RTCRtpReceiver:
             else:
                 packet._data = b""
         except ValueError as exc:
-            self.__log_debug("x RTP payload parsing failed: %s", exc)
+            self.__log_debug(f"x RTP payload parsing failed: {exc}")
             return
 
         # try to re-assemble encoded frame
@@ -530,7 +530,7 @@ class RTCRtpReceiver:
         self.__rtcp_exited.set()
 
     async def _send_rtcp(self, packet) -> None:
-        self.__log_debug("> %s", packet)
+        self.__log_debug(f"> {packet}")
         try:
             await self.transport._send_rtp(bytes(packet))
         except ConnectionError:
@@ -570,4 +570,4 @@ class RTCRtpReceiver:
             self.__decoder_thread = None
 
     def __log_debug(self, msg: str, *args) -> None:
-        logger.debug("receiver(%s) " + msg, self.__kind, *args)
+        logger.debug(f"receiver(%s) {msg}", self.__kind, *args)

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -235,7 +235,7 @@ class RTCRtpSender:
                 bitrate, ssrcs = unpack_remb_fci(packet.fci)
                 if self._ssrc in ssrcs:
                     self.__log_debug(
-                        "- receiver estimated maximum bitrate %d bps", bitrate
+                        f"- receiver estimated maximum bitrate {bitrate} bps"
                     )
                     if self.__encoder and hasattr(self.__encoder, "target_bitrate"):
                         self.__encoder.target_bitrate = bitrate
@@ -268,7 +268,7 @@ class RTCRtpSender:
                 )
                 self.__rtx_sequence_number = uint16_add(self.__rtx_sequence_number, 1)
 
-            self.__log_debug("> %s", packet)
+            self.__log_debug(f"> {packet}")
             packet_bytes = packet.serialize(self.__rtp_header_extensions_map)
             await self.transport._send_rtp(packet_bytes)
 
@@ -309,7 +309,7 @@ class RTCRtpSender:
                     packet.extensions.mid = self.__mid
 
                     # send packet
-                    self.__log_debug("> %s", packet)
+                    self.__log_debug(f"> {packet}")
                     self.__rtp_history[
                         packet.sequence_number % RTP_HISTORY_SIZE
                     ] = packet
@@ -383,7 +383,7 @@ class RTCRtpSender:
     async def _send_rtcp(self, packets: List[AnyRtcpPacket]) -> None:
         payload = b""
         for packet in packets:
-            self.__log_debug("> %s", packet)
+            self.__log_debug(f"> {packet}")
             payload += bytes(packet)
 
         try:
@@ -392,4 +392,4 @@ class RTCRtpSender:
             pass
 
     def __log_debug(self, msg: str, *args) -> None:
-        logger.debug("sender(%s) " + msg, self.__kind, *args)
+        logger.debug(f"sender(%s) {msg}", self.__kind, *args)

--- a/src/aiortc/rtp.py
+++ b/src/aiortc/rtp.py
@@ -572,7 +572,7 @@ class RtcpPacket:
         while pos < len(data):
             if len(data) < pos + RTCP_HEADER_LENGTH:
                 raise ValueError(
-                    "RTCP packet length is less than %d bytes" % RTCP_HEADER_LENGTH
+                    f"RTCP packet length is less than {RTCP_HEADER_LENGTH} bytes"
                 )
 
             v_p_count, packet_type, length = unpack("!BBH", data[pos : pos + 4])
@@ -632,19 +632,16 @@ class RtpPacket:
         self.padding_size = 0
 
     def __repr__(self) -> str:
-        return "RtpPacket(seq=%d, ts=%s, marker=%d, payload=%d, %d bytes)" % (
-            self.sequence_number,
-            self.timestamp,
-            self.marker,
-            self.payload_type,
-            len(self.payload),
+        return (
+            f"RtpPacket(seq={self.sequence_number}, ts={self.timestamp}, "
+            f"marker={self.marker}, payload={self.payload_type}, {len(self.payload)} bytes)"
         )
 
     @classmethod
     def parse(cls, data: bytes, extensions_map=HeaderExtensionsMap()):
         if len(data) < RTP_HEADER_LENGTH:
             raise ValueError(
-                "RTP packet length is less than %d bytes" % RTP_HEADER_LENGTH
+                f"RTP packet length is less than {RTP_HEADER_LENGTH} bytes"
             )
 
         v_p_x_cc, m_pt, sequence_number, timestamp, ssrc = unpack("!BBHLL", data[0:12])


### PR DESCRIPTION
The minimal python version for `aiortc` is 3.6 so we can replace all old-style formatting `%` by using f-strings which available from python 3.6.