### PR TITLE
Add mypy job to .travis.yml

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,3 @@
+[report]
+exclude_lines =
+    pragma: no cover

--- a/.travis.yml
+++ b/.travis.yml
@@ -21,7 +21,7 @@ language: python
 matrix:
   include:
   - env: BUILD=lint
-    install: pip install black flake8 isort
+    install: pip install black flake8 isort mypy
     python: "3.6"
   - env: BUILD=test
     language: generic

--- a/.travis/script
+++ b/.travis/script
@@ -6,6 +6,7 @@ if [ "$BUILD" = "lint" ]; then
     flake8 examples src tests
     isort -c -df -rc examples src tests
     black --check --diff examples src tests
+    mypy src
 elif [ "$BUILD" = "sdist" ]; then
     python3 setup.py sdist
     if [ -n "$TRAVIS_TAG" ]; then

--- a/mypy.ini
+++ b/mypy.ini
@@ -1,0 +1,10 @@
+[mypy]
+warn_redundant_casts = True
+warn_unused_ignores = True
+
+ignore_missing_imports = True
+follow_imports = skip
+
+mypy_path = stubs
+
+strict_optional = False

--- a/src/aiortc/codecs/__init__.py
+++ b/src/aiortc/codecs/__init__.py
@@ -22,7 +22,7 @@ PCMA_CODEC = RTCRtpCodecParameters(
     mimeType="audio/PCMA", clockRate=8000, channels=1, payloadType=8
 )
 
-CODECS = {
+CODECS: Dict[str, List[RTCRtpCodecParameters]] = {
     "audio": [
         RTCRtpCodecParameters(
             mimeType="audio/opus", clockRate=48000, channels=2, payloadType=96
@@ -31,8 +31,8 @@ CODECS = {
         PCMA_CODEC,
     ],
     "video": [],
-}  # type: Dict[str, List[RTCRtpCodecParameters]]
-HEADER_EXTENSIONS = {
+}
+HEADER_EXTENSIONS: Dict[str, List[RTCRtpHeaderExtensionParameters]] = {
     "audio": [
         RTCRtpHeaderExtensionParameters(id=1, uri="urn:ietf:params:rtp-hdrext:sdes:mid")
     ],
@@ -44,7 +44,7 @@ HEADER_EXTENSIONS = {
             id=2, uri="http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
         ),
     ],
-}  # type: Dict[str, List[RTCRtpHeaderExtensionParameters]]
+}
 
 
 def init_codecs() -> None:

--- a/src/aiortc/codecs/base.py
+++ b/src/aiortc/codecs/base.py
@@ -9,7 +9,7 @@ from ..jitterbuffer import JitterFrame
 class Decoder(metaclass=ABCMeta):
     @abstractmethod
     def decode(self, encoded_frame: JitterFrame) -> List[Frame]:
-        pass
+        pass  # pragma: no cover
 
 
 class Encoder(metaclass=ABCMeta):
@@ -17,4 +17,4 @@ class Encoder(metaclass=ABCMeta):
     def encode(
         self, frame: Frame, force_keyframe: bool = False
     ) -> Tuple[List[bytes], int]:
-        pass
+        pass  # pragma: no cover

--- a/src/aiortc/codecs/g711.py
+++ b/src/aiortc/codecs/g711.py
@@ -19,7 +19,7 @@ class PcmDecoder(ABC, Decoder):
     @staticmethod
     @abstractmethod
     def _convert(data: bytes, width: int) -> bytes:
-        ...
+        pass  # pragma: no cover
 
     def decode(self, encoded_frame: JitterFrame) -> List[Frame]:
         frame = AudioFrame(format="s16", layout="mono", samples=SAMPLES_PER_FRAME)
@@ -34,7 +34,7 @@ class PcmEncoder(ABC, Encoder):
     @staticmethod
     @abstractmethod
     def _convert(data: bytes, width: int) -> bytes:
-        ...
+        pass  # pragma: no cover
 
     def __init__(self) -> None:
         self.rate_state: Optional[Tuple[int, Tuple[Tuple[int, int], ...]]] = None

--- a/src/aiortc/codecs/h264.py
+++ b/src/aiortc/codecs/h264.py
@@ -116,7 +116,7 @@ class H264Decoder(Decoder):
 
 class H264Encoder(Encoder):
     def __init__(self) -> None:
-        self.codec = None  # type: Optional[av.CodecContext]
+        self.codec: Optional[av.CodecContext] = None
 
     @staticmethod
     def _packetize_fu_a(data: bytes) -> List[bytes]:

--- a/src/aiortc/codecs/opus.py
+++ b/src/aiortc/codecs/opus.py
@@ -55,9 +55,7 @@ class OpusEncoder(Encoder):
             "unsigned char []", SAMPLES_PER_FRAME * CHANNELS * SAMPLE_WIDTH
         )
         self.buffer = ffi.buffer(self.cdata)
-        self.rate_state = (
-            None
-        )  # type: Optional[Tuple[int, Tuple[Tuple[int, int], ...]]]
+        self.rate_state: Optional[Tuple[int, Tuple[Tuple[int, int], ...]]] = (None)
 
     def __del__(self) -> None:
         lib.opus_encoder_destroy(self.encoder)

--- a/src/aiortc/codecs/vpx.py
+++ b/src/aiortc/codecs/vpx.py
@@ -1,7 +1,7 @@
 import multiprocessing
 import random
 from struct import pack, unpack_from
-from typing import List, Tuple, Type, TypeVar
+from typing import List, Tuple, Type, TypeVar, cast
 
 from av import VideoFrame
 from av.frame import Frame
@@ -183,7 +183,7 @@ class Vp8Decoder(Decoder):
         lib.vpx_codec_destroy(self.codec)
 
     def decode(self, encoded_frame: JitterFrame) -> List[Frame]:
-        frames = []  # type: List[Frame]
+        frames: List[Frame] = []
         result = lib.vpx_codec_decode(
             self.codec,
             encoded_frame.data,
@@ -209,7 +209,7 @@ class Vp8Decoder(Decoder):
                     i_pos = 0
 
                     o_stride = frame.planes[p].line_size
-                    o_buf = memoryview(frame.planes[p])
+                    o_buf = memoryview(cast(bytes, frame.planes[p]))
                     o_pos = 0
 
                     div = p and 2 or 1

--- a/src/aiortc/events.py
+++ b/src/aiortc/events.py
@@ -12,9 +12,9 @@ class RTCTrackEvent:
     :class:`MediaStreamTrack` is added by the remote party.
     """
 
-    receiver = attr.ib()  # type: RTCRtpReceiver
+    receiver: RTCRtpReceiver = attr.ib()
     "The :class:`RTCRtpReceiver` associated with the event."
-    track = attr.ib()  # type: MediaStreamTrack
+    track: MediaStreamTrack = attr.ib()
     "The :class:`MediaStreamTrack` associated with the event."
-    transceiver = attr.ib()  # type: RTCRtpTransceiver
+    transceiver: RTCRtpTransceiver = attr.ib()
     "The :class:`RTCRtpTransceiver` associated with the event."

--- a/src/aiortc/jitterbuffer.py
+++ b/src/aiortc/jitterbuffer.py
@@ -15,10 +15,8 @@ class JitterBuffer:
     def __init__(self, capacity: int, prefetch: int = 0) -> None:
         assert capacity & (capacity - 1) == 0, "capacity must be a power of 2"
         self._capacity = capacity
-        self._origin = None  # type: Optional[int]
-        self._packets = [
-            None for i in range(capacity)
-        ]  # type: List[Optional[RtpPacket]]
+        self._origin: Optional[int] = None
+        self._packets: List[Optional[RtpPacket]] = [None for i in range(capacity)]
         self._prefetch = prefetch
 
     @property

--- a/src/aiortc/mediastreams.py
+++ b/src/aiortc/mediastreams.py
@@ -73,6 +73,9 @@ class AudioStreamTrack(MediaStreamTrack):
 
     kind = "audio"
 
+    _start: float
+    _timestamp: int
+
     async def recv(self) -> Frame:
         """
         Receive the next :class:`~av.audio.frame.AudioFrame`.
@@ -109,6 +112,9 @@ class VideoStreamTrack(MediaStreamTrack):
     """
 
     kind = "video"
+
+    _start: float
+    _timestamp: int
 
     async def next_timestamp(self) -> Tuple[int, fractions.Fraction]:
         if self.readyState != "live":

--- a/src/aiortc/rate.py
+++ b/src/aiortc/rate.py
@@ -38,8 +38,8 @@ class AimdRateControl:
         self.var_max_bitrate_kbps = 0.4
         self.current_bitrate = 30000000
         self.current_bitrate_initialized = False
-        self.first_estimated_throughput_time = None  # type: Optional[int]
-        self.last_change_ms = None  # type: Optional[int]
+        self.first_estimated_throughput_time: Optional[int] = None
+        self.last_change_ms: Optional[int] = None
         self.near_max = False
         self.latest_estimated_throughput = 30000000
         self.rtt = 200
@@ -182,7 +182,7 @@ class AimdRateControl:
 
 class TimestampGroup:
     def __init__(self, timestamp: Optional[int] = None) -> None:
-        self.arrival_time = None  # type: Optional[int]
+        self.arrival_time: Optional[int] = None
         self.first_timestamp = timestamp
         self.last_timestamp = timestamp
         self.size = 0
@@ -205,8 +205,8 @@ class InterArrival:
     def __init__(self, group_length: int, timestamp_to_ms: float) -> None:
         self.group_length = group_length
         self.timestamp_to_ms = timestamp_to_ms
-        self.current_group = None  # type: Optional[TimestampGroup]
-        self.previous_group = None  # type: Optional[TimestampGroup]
+        self.current_group: Optional[TimestampGroup] = None
+        self.previous_group: Optional[TimestampGroup] = None
 
     def compute_deltas(
         self, timestamp: int, arrival_time: int, packet_size: int
@@ -271,11 +271,11 @@ class OveruseDetector:
 
     def __init__(self) -> None:
         self.hypothesis = BandwidthUsage.NORMAL
-        self.last_update_ms = None  # type: Optional[int]
+        self.last_update_ms: Optional[int] = None
         self.k_up = 0.0087
         self.k_down = 0.039
         self.overuse_counter = 0
-        self.overuse_time = None  # type: Optional[float]
+        self.overuse_time: Optional[float] = None
         self.overuse_time_threshold = 10
         self.previous_offset = 0.0
         self.threshold = 12.5
@@ -346,7 +346,7 @@ class OveruseEstimator:
         self._offset = 0.0
         self.previous_offset = 0.0
         self.slope = 1 / 64
-        self.ts_delta_hist = []  # type: List[float]
+        self.ts_delta_hist: List[float] = []
 
         self.avg_noise = 0.0
         self.var_noise = 50.0
@@ -460,7 +460,7 @@ class RateCounter:
 
     def __init__(self, window_size: int, scale: int = 8000) -> None:
         self._origin_index = 0
-        self._origin_ms = None  # type: Optional[int]
+        self._origin_ms: Optional[int] = None
         self._scale = scale
         self._window_size = window_size
         self.reset()
@@ -514,8 +514,8 @@ class RemoteBitrateEstimator:
         self.estimator = OveruseEstimator()
         self.detector = OveruseDetector()
         self.rate_control = AimdRateControl()
-        self.last_update_ms = None  # type: Optional[int]
-        self.ssrcs = {}  # type: Dict[int, int]
+        self.last_update_ms: Optional[int] = None
+        self.ssrcs: Dict[int, int] = {}
 
     def add(
         self, arrival_time_ms: int, abs_send_time: int, payload_size: int, ssrc: int

--- a/src/aiortc/rtcdatachannel.py
+++ b/src/aiortc/rtcdatachannel.py
@@ -16,27 +16,27 @@ class RTCDataChannelParameters:
     configuration of an :class:`RTCDataChannel`.
     """
 
-    label = attr.ib(default="")  # type: str
+    label: str = attr.ib(default="")
     "A name describing the data channel."
 
-    maxPacketLifeTime = attr.ib(default=None)  # type: Optional[int]
+    maxPacketLifeTime: Optional[int] = attr.ib(default=None)
     "The maximum time in milliseconds during which transmissions are attempted."
 
-    maxRetransmits = attr.ib(default=None)  # type: Optional[int]
+    maxRetransmits: Optional[int] = attr.ib(default=None)
     "The maximum number of retransmissions that are attempted."
 
-    ordered = attr.ib(default=True)  # type: bool
+    ordered: bool = attr.ib(default=True)
     "Whether the data channel guarantees in-order delivery of messages."
 
-    protocol = attr.ib(default="")  # type: str
+    protocol: str = attr.ib(default="")
     "The name of the subprotocol in use."
 
-    negotiated = attr.ib(default=False)  # type: bool
+    negotiated: bool = attr.ib(default=False)
     """
     Whether data channel will be negotiated out of-band, where both sides
     create data channel with an agreed-upon ID."""
 
-    id = attr.ib(default=None)  # type: Optional[int]
+    id: Optional[int] = attr.ib(default=None)
     """
     An numeric ID for the channel; permitted values are 0-65534.
     If you don't include this option, the user agent will select an ID for you.

--- a/src/aiortc/rtcdtlstransport.py
+++ b/src/aiortc/rtcdtlstransport.py
@@ -148,10 +148,10 @@ class RTCDtlsFingerprint:
     algorithm and certificate fingerprint.
     """
 
-    algorithm = attr.ib()  # type: str
+    algorithm: str = attr.ib()
     "The hash function name, for instance `'sha-256'`."
 
-    value = attr.ib()  # type: str
+    value: str = attr.ib()
     "The fingerprint value."
 
 
@@ -181,7 +181,8 @@ class RTCCertificate:
         """
         return [
             RTCDtlsFingerprint(
-                algorithm="sha-256", value=certificate_digest(self._cert._x509)
+                algorithm="sha-256",
+                value=certificate_digest(self._cert._x509),  # type: ignore
             )
         ]
 
@@ -212,8 +213,8 @@ class RTCCertificate:
             verify_callback,
         )
 
-        _openssl_assert(lib.SSL_CTX_use_certificate(ctx, self._cert._x509) == 1)
-        _openssl_assert(lib.SSL_CTX_use_PrivateKey(ctx, self._key._evp_pkey) == 1)
+        _openssl_assert(lib.SSL_CTX_use_certificate(ctx, self._cert._x509) == 1)  # type: ignore
+        _openssl_assert(lib.SSL_CTX_use_PrivateKey(ctx, self._key._evp_pkey) == 1)  # type: ignore
         _openssl_assert(lib.SSL_CTX_set_cipher_list(ctx, b"HIGH:!CAMELLIA:!aNULL") == 1)
         _openssl_assert(
             lib.SSL_CTX_set_tlsext_use_srtp(ctx, b"SRTP_AES128_CM_SHA1_80") == 0
@@ -241,10 +242,10 @@ class RTCDtlsParameters:
     DTLS configuration.
     """
 
-    fingerprints = attr.ib(default=attr.Factory(list))  # type: List[RTCDtlsFingerprint]
+    fingerprints: List[RTCDtlsFingerprint] = attr.ib(default=attr.Factory(list))
     "List of :class:`RTCDtlsFingerprint`, one fingerprint for each certificate."
 
-    role = attr.ib(default="auto")  # type: str
+    role: str = attr.ib(default="auto")
     "The DTLS role, with a default of auto."
 
 
@@ -256,11 +257,11 @@ class RtpRouter:
     """
 
     def __init__(self) -> None:
-        self.receivers = set()  # type: Set
-        self.senders = {}  # type: Dict[int, Any]
-        self.mid_table = {}  # type: Dict[str, Any]
-        self.ssrc_table = {}  # type: Dict[int, Any]
-        self.payload_type_table = {}  # type: Dict[int, Any]
+        self.receivers: Set = set()
+        self.senders: Dict[int, Any] = {}
+        self.mid_table: Dict[str, Any] = {}
+        self.ssrc_table: Dict[int, Any] = {}
+        self.payload_type_table: Dict[int, Any] = {}
 
     def register_receiver(
         self,
@@ -365,7 +366,7 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
         self._rtp_router = RtpRouter()
         self._state = State.NEW
         self._stats_id = "transport_" + str(id(self))
-        self._task = None  # type: Optional[asyncio.Future[None]]
+        self._task: Optional[asyncio.Future[None]] = None
         self._transport = transport
 
         # counters
@@ -375,8 +376,8 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
         self.__tx_packets = 0
 
         # SRTP
-        self._rx_srtp = None  # type: Session
-        self._tx_srtp = None  # type: Session
+        self._rx_srtp: Session = None
+        self._tx_srtp: Session = None
 
         # SSL init
         self.__ctx = certificate._create_ssl_context()

--- a/src/aiortc/rtcicetransport.py
+++ b/src/aiortc/rtcicetransport.py
@@ -29,12 +29,12 @@ class RTCIceCandidate:
     establish an RTCPeerConnection.
     """
 
-    component = attr.ib()  # type: int
-    foundation = attr.ib()  # type: str
-    ip = attr.ib()  # type: str
-    port = attr.ib()  # type: int
-    priority = attr.ib()  # type: int
-    protocol = attr.ib()  # type: str
+    component: int = attr.ib()
+    foundation: str = attr.ib()
+    ip: str = attr.ib()
+    port: int = attr.ib()
+    priority: int = attr.ib()
+    protocol: str = attr.ib()
     type = attr.ib()
     relatedAddress = attr.ib(default=None)
     relatedPort = attr.ib(default=None)
@@ -50,13 +50,13 @@ class RTCIceParameters:
     fragment and password and other ICE-related parameters.
     """
 
-    usernameFragment = attr.ib(default=None)  # type: Optional[str]
+    usernameFragment: Optional[str] = attr.ib(default=None)
     "ICE username fragment."
 
-    password = attr.ib(default=None)  # type: Optional[str]
+    password: Optional[str] = attr.ib(default=None)
     "ICE password."
 
-    iceLite = attr.ib(default=False)  # type: bool
+    iceLite: bool = attr.ib(default=False)
 
 
 def candidate_from_aioice(x: Candidate) -> RTCIceCandidate:
@@ -90,7 +90,7 @@ def candidate_to_aioice(x: RTCIceCandidate) -> Candidate:
 
 
 def connection_kwargs(servers: List[RTCIceServer]) -> Dict[str, Any]:
-    kwargs = {}  # type: Dict[str, Any]
+    kwargs: Dict[str, Any] = {}
 
     for server in servers:
         if isinstance(server.urls, list):
@@ -146,7 +146,7 @@ def parse_stun_turn_uri(uri: str) -> Dict[str, Any]:
         raise ValueError("malformed uri")
 
     # set port
-    parsed = match.groupdict()
+    parsed: Dict[str, Any] = match.groupdict()
     if parsed["port"]:
         parsed["port"] = int(parsed["port"])
     elif parsed["scheme"] in ["stuns", "turns"]:
@@ -238,7 +238,7 @@ class RTCIceTransport(AsyncIOEventEmitter):
 
     def __init__(self, gatherer: RTCIceGatherer) -> None:
         super().__init__()
-        self.__start = None  # type: Optional[asyncio.Event]
+        self.__start: Optional[asyncio.Event] = None
         self.__iceGatherer = gatherer
         self.__state = "new"
         self._connection = gatherer._connection

--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -77,7 +77,7 @@ def find_common_codecs(
     remote_codecs: List[RTCRtpCodecParameters],
 ) -> List[RTCRtpCodecParameters]:
     common = []
-    common_base = {}  # type: Dict[int, RTCRtpCodecParameters]
+    common_base: Dict[int, RTCRtpCodecParameters] = {}
     for c in remote_codecs:
         # for RTX, check we accepted the base codec
         if is_rtx(c):
@@ -274,32 +274,32 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         self.__certificates = [RTCCertificate.generateCertificate()]
         self.__cname = f"{uuid.uuid4()}"
         self.__configuration = configuration or RTCConfiguration()
-        self.__iceTransports = set()  # type: Set[RTCIceTransport]
-        self.__initialOfferer = None  # type: Optional[bool]
-        self.__remoteDtls = (
-            {}
-        )  # type: Dict[Union[RTCRtpTransceiver, RTCSctpTransport], RTCDtlsParameters]
-        self.__remoteIce = (
-            {}
-        )  # type: Dict[Union[RTCRtpTransceiver, RTCSctpTransport], RTCIceParameters]
-        self.__seenMids = set()  # type: Set[str]
-        self.__sctp = None  # type: Optional[RTCSctpTransport]
-        self.__sctp_mline_index = None  # type: Optional[int]
+        self.__iceTransports: Set[RTCIceTransport] = set()
+        self.__initialOfferer: Optional[bool] = None
+        self.__remoteDtls: Dict[
+            Union[RTCRtpTransceiver, RTCSctpTransport], RTCDtlsParameters
+        ] = ({})
+        self.__remoteIce: Dict[
+            Union[RTCRtpTransceiver, RTCSctpTransport], RTCIceParameters
+        ] = ({})
+        self.__seenMids: Set[str] = set()
+        self.__sctp: Optional[RTCSctpTransport] = None
+        self.__sctp_mline_index: Optional[int] = None
         self._sctpLegacySdp = True
-        self.__sctpRemotePort = None  # type: Optional[int]
+        self.__sctpRemotePort: Optional[int] = None
         self.__sctpRemoteCaps = None
         self.__stream_id = str(uuid.uuid4())
-        self.__transceivers = []  # type: List[RTCRtpTransceiver]
+        self.__transceivers: List[RTCRtpTransceiver] = []
 
         self.__iceConnectionState = "new"
         self.__iceGatheringState = "new"
         self.__isClosed = False
         self.__signalingState = "stable"
 
-        self.__currentLocalDescription = None  # type: Optional[sdp.SessionDescription]
-        self.__currentRemoteDescription = None  # type: Optional[sdp.SessionDescription]
-        self.__pendingLocalDescription = None  # type: Optional[sdp.SessionDescription]
-        self.__pendingRemoteDescription = None  # type: Optional[sdp.SessionDescription]
+        self.__currentLocalDescription: Optional[sdp.SessionDescription] = None
+        self.__currentRemoteDescription: Optional[sdp.SessionDescription] = None
+        self.__pendingLocalDescription: Optional[sdp.SessionDescription] = None
+        self.__pendingRemoteDescription: Optional[sdp.SessionDescription] = None
 
     @property
     def iceConnectionState(self) -> str:
@@ -994,9 +994,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
             rtcp=media.rtp.rtcp,
         )
         if len(media.ssrc):
-            encodings = (
-                OrderedDict()
-            )  # type: OrderedDict[int, RTCRtpDecodingParameters]
+            encodings: OrderedDict[int, RTCRtpDecodingParameters] = (OrderedDict())
             for codec in transceiver._codecs:
                 if is_rtx(codec):
                     if codec.parameters["apt"] in encodings and len(media.ssrc) == 2:

--- a/src/aiortc/rtcrtpparameters.py
+++ b/src/aiortc/rtcrtpparameters.py
@@ -11,13 +11,13 @@ class RTCRtpCodecCapability:
     codec capabilities.
     """
 
-    mimeType = attr.ib(type=str)  # type: str
+    mimeType: str = attr.ib()
     "The codec MIME media type/subtype, for instance `'audio/PCMU'`."
-    clockRate = attr.ib(type=int)  # type: int
+    clockRate: int = attr.ib()
     "The codec clock rate expressed in Hertz."
-    channels = attr.ib(default=None)  # type: int
+    channels: int = attr.ib(default=None)
     "The number of channels supported (e.g. two for stereo)."
-    parameters = attr.ib(default=attr.Factory(OrderedDict))  # type: OrderedDict
+    parameters: OrderedDict = attr.ib(default=attr.Factory(OrderedDict))
     "Codec-specific parameters available for signaling."
 
     @property
@@ -32,17 +32,17 @@ class RTCRtpCodecParameters:
     codec settings.
     """
 
-    mimeType = attr.ib(type=str)  # type: str
+    mimeType: str = attr.ib()
     "The codec MIME media type/subtype, for instance `'audio/PCMU'`."
-    clockRate = attr.ib(type=int)  # type: int
+    clockRate: int = attr.ib()
     "The codec clock rate expressed in Hertz."
-    channels = attr.ib(default=None)  # type: int
+    channels: int = attr.ib(default=None)
     "The number of channels supported (e.g. two for stereo)."
-    payloadType = attr.ib(default=None)  # type: int
+    payloadType: int = attr.ib(default=None)
     "The value that goes in the RTP Payload Type Field."
-    rtcpFeedback = attr.ib(default=attr.Factory(list))  # type: List[RTCRtcpFeedback]
+    rtcpFeedback: List["RTCRtcpFeedback"] = attr.ib(default=attr.Factory(list))
     "Transport layer and codec-specific feedback messages for this codec."
-    parameters = attr.ib(default=attr.Factory(OrderedDict))  # type: OrderedDict
+    parameters: OrderedDict = attr.ib(default=attr.Factory(OrderedDict))
     "Codec-specific parameters available for signaling."
 
     @property
@@ -58,14 +58,14 @@ class RTCRtpCodecParameters:
 
 @attr.s
 class RTCRtpRtxParameters:
-    ssrc = attr.ib(type=int)  # type: int
+    ssrc: int = attr.ib()
 
 
 @attr.s
 class RTCRtpCodingParameters:
-    ssrc = attr.ib(type=int)  # type: int
-    payloadType = attr.ib(type=int)  # type: int
-    rtx = attr.ib(default=None)  # type: RTCRtpRtxParameters
+    ssrc: int = attr.ib()
+    payloadType: int = attr.ib()
+    rtx: RTCRtpRtxParameters = attr.ib(default=None)
 
 
 @attr.s
@@ -85,7 +85,7 @@ class RTCRtpHeaderExtensionCapability:
     on a supported header extension.
     """
 
-    uri = attr.ib(type=str)  # type: str
+    uri: str = attr.ib()
     "The URI of the RTP header extension."
 
 
@@ -97,9 +97,9 @@ class RTCRtpHeaderExtensionParameters:
     :class:`RTCRtpReceiver`.
     """
 
-    id = attr.ib(type=int)  # type: int
+    id: int = attr.ib()
     "The value that goes in the packet."
-    uri = attr.ib(type=str)  # type: str
+    uri: str = attr.ib()
     "The URI of the RTP header extension."
 
 
@@ -110,11 +110,11 @@ class RTCRtpCapabilities:
     support codecs and header extensions.
     """
 
-    codecs = attr.ib(default=attr.Factory(list))  # type: List[RTCRtpCodecCapability]
+    codecs: List[RTCRtpCodecCapability] = attr.ib(default=attr.Factory(list))
     "A list of :class:`RTCRtpCodecCapability`."
-    headerExtensions = attr.ib(
+    headerExtensions: List[RTCRtpHeaderExtensionCapability] = attr.ib(
         default=attr.Factory(list)
-    )  # type: List[RTCRtpHeaderExtensionCapability]
+    )
     "A list of :class:`RTCRtpHeaderExtensionCapability`."
 
 
@@ -124,8 +124,8 @@ class RTCRtcpFeedback:
     The :class:`RTCRtcpFeedback` dictionary provides information on RTCP feedback messages.
     """
 
-    type = attr.ib()  # type: str
-    parameter = attr.ib(default=None)  # type: str
+    type: str = attr.ib()
+    parameter: str = attr.ib(default=None)
 
 
 @attr.s
@@ -134,11 +134,11 @@ class RTCRtcpParameters:
     The :class:`RTCRtcpParameters` dictionary provides information on RTCP settings.
     """
 
-    cname = attr.ib(default=None)  # type: str
+    cname: str = attr.ib(default=None)
     "The Canonical Name (CNAME) used by RTCP."
-    mux = attr.ib(default=False)  # type: bool
+    mux: bool = attr.ib(default=False)
     "Whether RTP and RTCP are multiplexed."
-    ssrc = attr.ib(default=None)  # type: int
+    ssrc: int = attr.ib(default=None)
     "The Synchronization Source identifier."
 
 
@@ -149,27 +149,23 @@ class RTCRtpParameters:
     an :class:`RTCRtpReceiver` or an :class:`RTCRtpSender`.
     """
 
-    codecs = attr.ib(default=attr.Factory(list))  # type: List[RTCRtpCodecParameters]
+    codecs: List[RTCRtpCodecParameters] = attr.ib(default=attr.Factory(list))
     "A list of :class:`RTCRtpCodecParameters` to send or receive."
-    headerExtensions = attr.ib(
+    headerExtensions: List[RTCRtpHeaderExtensionParameters] = attr.ib(
         default=attr.Factory(list)
-    )  # type: List[RTCRtpHeaderExtensionParameters]
+    )
     "A list of :class:`RTCRtpHeaderExtensionParameters`."
-    muxId = attr.ib(default="")  # type: str
+    muxId: str = attr.ib(default="")
     "The muxId assigned to the RTP stream, if any, empty string if unset."
-    rtcp = attr.ib(default=attr.Factory(RTCRtcpParameters))  # type: RTCRtcpParameters
+    rtcp: RTCRtcpParameters = attr.ib(default=attr.Factory(RTCRtcpParameters))
     "Parameters to configure RTCP."
 
 
 @attr.s
 class RTCRtpReceiveParameters(RTCRtpParameters):
-    encodings = attr.ib(
-        default=attr.Factory(list)
-    )  # type: List[RTCRtpDecodingParameters]
+    encodings: List[RTCRtpDecodingParameters] = attr.ib(default=attr.Factory(list))
 
 
 @attr.s
 class RTCRtpSendParameters(RTCRtpParameters):
-    encodings = attr.ib(
-        default=attr.Factory(list)
-    )  # type: List[RTCRtpEncodingParameters]
+    encodings: List[RTCRtpEncodingParameters] = attr.ib(default=attr.Factory(list))

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -74,8 +74,8 @@ def decoder_worker(loop, input_q, output_q):
 
 class NackGenerator:
     def __init__(self) -> None:
-        self.max_seq = None  # type: Optional[int]
-        self.missing = set()  # type: Set[int]
+        self.max_seq: Optional[int] = None
+        self.missing: Set[int] = set()
 
     def add(self, packet: RtpPacket) -> bool:
         missed = False
@@ -100,16 +100,16 @@ class NackGenerator:
 
 class StreamStatistics:
     def __init__(self, clockrate: int) -> None:
-        self.base_seq = None  # type: Optional[int]
-        self.max_seq = None  # type: Optional[int]
+        self.base_seq: Optional[int] = None
+        self.max_seq: Optional[int] = None
         self.cycles = 0
         self.packets_received = 0
 
         # jitter
         self._clockrate = clockrate
         self._jitter_q4 = 0
-        self._last_arrival = None  # type: Optional[int]
-        self._last_timestamp = None  # type: Optional[int]
+        self._last_arrival: Optional[int] = None
+        self._last_timestamp: Optional[int] = None
 
         # fraction lost
         self._expected_prior = 0
@@ -170,7 +170,7 @@ class RemoteStreamTrack(MediaStreamTrack):
     def __init__(self, kind: str) -> None:
         super().__init__()
         self.kind = kind
-        self._queue = asyncio.Queue()  # type: asyncio.Queue
+        self._queue: asyncio.Queue = asyncio.Queue()
 
     async def recv(self) -> Frame:
         """
@@ -188,8 +188,8 @@ class RemoteStreamTrack(MediaStreamTrack):
 
 class TimestampMapper:
     def __init__(self) -> None:
-        self._last = None  # type: Optional[int]
-        self._origin = None  # type: Optional[int]
+        self._last: Optional[int] = None
+        self._origin: Optional[int] = None
 
     def map(self, timestamp: int) -> int:
         if self._origin is None:
@@ -210,9 +210,9 @@ class RTCRtpContributingSource:
     a contributing source (CSRC).
     """
 
-    timestamp = attr.ib(type=datetime.datetime)  # type: datetime.datetime
+    timestamp: datetime.datetime = attr.ib()
     "The timestamp associated with this source."
-    source = attr.ib(type=int)  # type: int
+    source: int = attr.ib()
     "The CSRC identifier associated with this source."
 
 
@@ -223,9 +223,9 @@ class RTCRtpSynchronizationSource:
     a synchronization source (SSRC).
     """
 
-    timestamp = attr.ib(type=datetime.datetime)  # type: datetime.datetime
+    timestamp: datetime.datetime = attr.ib()
     "The timestamp associated with this source."
-    source = attr.ib(type=int)  # type: int
+    source: int = attr.ib()
     "The SSRC identifier associated with this source."
 
 
@@ -242,10 +242,10 @@ class RTCRtpReceiver:
         if transport.state == "closed":
             raise InvalidStateError
 
-        self.__active_ssrc = {}  # type: Dict[int, datetime.datetime]
-        self.__codecs = {}  # type: Dict[int, RTCRtpCodecParameters]
-        self.__decoder_queue = queue.Queue()  # type: queue.Queue
-        self.__decoder_thread = None  # type: Optional[threading.Thread]
+        self.__active_ssrc: Dict[int, datetime.datetime] = {}
+        self.__codecs: Dict[int, RTCRtpCodecParameters] = {}
+        self.__decoder_queue: queue.Queue = queue.Queue()
+        self.__decoder_thread: Optional[threading.Thread] = None
         self.__kind = kind
         if kind == "audio":
             self.__jitter_buffer = JitterBuffer(capacity=16, prefetch=4)
@@ -255,20 +255,20 @@ class RTCRtpReceiver:
             self.__jitter_buffer = JitterBuffer(capacity=128)
             self.__nack_generator = NackGenerator()
             self.__remote_bitrate_estimator = RemoteBitrateEstimator()
-        self._track = None  # type: Optional[RemoteStreamTrack]
+        self._track: Optional[RemoteStreamTrack] = None
         self.__rtcp_exited = asyncio.Event()
-        self.__rtcp_task = None  # type: Optional[asyncio.Future[None]]
-        self.__rtx_ssrc = {}  # type: Dict[int, int]
+        self.__rtcp_task: Optional[asyncio.Future[None]] = None
+        self.__rtx_ssrc: Dict[int, int] = {}
         self.__started = False
         self.__stats = RTCStatsReport()
         self.__timestamp_mapper = TimestampMapper()
         self.__transport = transport
 
         # RTCP
-        self.__lsr = {}  # type: Dict[int, int]
-        self.__lsr_time = {}  # type: Dict[int, float]
-        self.__remote_streams = {}  # type: Dict[int, StreamStatistics]
-        self.__rtcp_ssrc = None  # type: Optional[int]
+        self.__lsr: Dict[int, int] = {}
+        self.__lsr_time: Dict[int, float] = {}
+        self.__remote_streams: Dict[int, StreamStatistics] = {}
+        self.__rtcp_ssrc: Optional[int] = None
 
     @property
     def transport(self) -> RTCDtlsTransport:
@@ -470,9 +470,9 @@ class RTCRtpReceiver:
         # parse codec-specific information
         try:
             if packet.payload:
-                packet._data = depayload(codec, packet.payload)
+                packet._data = depayload(codec, packet.payload)  # type: ignore
             else:
-                packet._data = b""
+                packet._data = b""  # type: ignore
         except ValueError as exc:
             self.__log_debug(f"x RTP payload parsing failed: {exc}")
             return

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -62,30 +62,30 @@ class RTCRtpSender:
         else:
             self.__kind = trackOrKind
             self.replaceTrack(None)
-        self.__cname = None  # type: Optional[str]
+        self.__cname: Optional[str] = None
         self._ssrc = random32()
         self._rtx_ssrc = random32()
         # FIXME: how should this be initialised?
         self._stream_id = str(uuid.uuid4())
-        self.__encoder = None  # type: Optional[Encoder]
+        self.__encoder: Optional[Encoder] = None
         self.__force_keyframe = False
         self.__loop = asyncio.get_event_loop()
-        self.__mid = None  # type: Optional[str]
+        self.__mid: Optional[str] = None
         self.__rtp_exited = asyncio.Event()
         self.__rtp_header_extensions_map = rtp.HeaderExtensionsMap()
-        self.__rtp_task = None  # type: Optional[asyncio.Future[None]]
-        self.__rtp_history = {}  # type: Dict[int, RtpPacket]
+        self.__rtp_task: Optional[asyncio.Future[None]] = None
+        self.__rtp_history: Dict[int, RtpPacket] = {}
         self.__rtcp_exited = asyncio.Event()
-        self.__rtcp_task = None  # type: Optional[asyncio.Future[None]]
-        self.__rtx_payload_type = None  # type: Optional[int]
+        self.__rtcp_task: Optional[asyncio.Future[None]] = None
+        self.__rtx_payload_type: Optional[int] = None
         self.__rtx_sequence_number = random16()
         self.__started = False
         self.__stats = RTCStatsReport()
         self.__transport = transport
 
         # stats
-        self.__lsr = None  # type: Optional[int]
-        self.__lsr_time = None  # type: Optional[float]
+        self.__lsr: Optional[int] = None
+        self.__lsr_time: Optional[float] = None
         self.__ntp_timestamp = 0
         self.__rtp_timestamp = 0
         self.__octet_count = 0
@@ -342,7 +342,7 @@ class RTCRtpSender:
                 await asyncio.sleep(0.5 + random.random())
 
                 # RTCP SR
-                packets = [
+                packets: List[AnyRtcpPacket] = [
                     RtcpSrPacket(
                         ssrc=self._ssrc,
                         sender_info=RtcpSenderInfo(
@@ -352,7 +352,7 @@ class RTCRtpSender:
                             octet_count=self.__octet_count,
                         ),
                     )
-                ]  # type: List[AnyRtcpPacket]
+                ]
                 self.__lsr = ((self.__ntp_timestamp) >> 16) & 0xFFFFFFFF
                 self.__lsr_time = time.time()
 

--- a/src/aiortc/rtcrtptransceiver.py
+++ b/src/aiortc/rtcrtptransceiver.py
@@ -31,21 +31,21 @@ class RTCRtpTransceiver:
     ):
         self.__direction = direction
         self.__kind = kind
-        self.__mid = None  # type: Optional[str]
-        self.__mline_index = None  # type: Optional[int]
+        self.__mid: Optional[str] = None
+        self.__mline_index: Optional[int] = None
         self.__receiver = receiver
         self.__sender = sender
         self.__stopped = False
 
-        self._currentDirection = None  # type: Optional[str]
-        self._offerDirection = None  # type: Optional[str]
-        self._preferred_codecs = []  # type: List[RTCRtpCodecCapability]
-        self._transport = None  # type: RTCDtlsTransport
+        self._currentDirection: Optional[str] = None
+        self._offerDirection: Optional[str] = None
+        self._preferred_codecs: List[RTCRtpCodecCapability] = []
+        self._transport: RTCDtlsTransport = None
 
         # FIXME: this is only used by RTCPeerConnection
         self._bundled = False
-        self._codecs = []  # type: List[RTCRtpCodecParameters]
-        self._headerExtensions = []  # type: List[RTCRtpHeaderExtensionParameters]
+        self._codecs: List[RTCRtpCodecParameters] = []
+        self._headerExtensions: List[RTCRtpHeaderExtensionParameters] = []
 
     @property
     def currentDirection(self) -> Optional[str]:
@@ -113,7 +113,7 @@ class RTCRtpTransceiver:
             self._preferred_codecs = []
 
         capabilities = get_capabilities(self.kind).codecs
-        unique = []  # type: List[RTCRtpCodecCapability]
+        unique: List[RTCRtpCodecCapability] = []
         for codec in reversed(codecs):
             if codec not in capabilities:
                 raise ValueError("Codec is not in capabilities")

--- a/src/aiortc/rtp.py
+++ b/src/aiortc/rtp.py
@@ -338,10 +338,10 @@ class RtcpReceiverInfo:
 
 @attr.s
 class RtcpSenderInfo:
-    ntp_timestamp = attr.ib()  # type: int
-    rtp_timestamp = attr.ib()  # type: int
-    packet_count = attr.ib()  # type: int
-    octet_count = attr.ib()  # type: int
+    ntp_timestamp: int = attr.ib()
+    rtp_timestamp: int = attr.ib()
+    packet_count: int = attr.ib()
+    octet_count: int = attr.ib()
 
     def __bytes__(self) -> bytes:
         return pack(
@@ -415,8 +415,8 @@ class RtcpPsfbPacket:
 
 @attr.s
 class RtcpRrPacket:
-    ssrc = attr.ib()  # type: int
-    reports = attr.ib(default=attr.Factory(list))  # type: List[RtcpReceiverInfo]
+    ssrc: int = attr.ib()
+    reports: List[RtcpReceiverInfo] = attr.ib(default=attr.Factory(list))
 
     def __bytes__(self) -> bytes:
         payload = pack("!L", self.ssrc)
@@ -449,7 +449,7 @@ class RtcpRtpfbPacket:
     media_ssrc = attr.ib()
 
     # generick NACK
-    lost = attr.ib(default=attr.Factory(list))  # type: List[int]
+    lost: List[int] = attr.ib(default=attr.Factory(list))
 
     def __bytes__(self) -> bytes:
         payload = pack("!LL", self.ssrc, self.media_ssrc)
@@ -485,7 +485,7 @@ class RtcpRtpfbPacket:
 
 @attr.s
 class RtcpSdesPacket:
-    chunks = attr.ib(default=attr.Factory(list))  # type: List[RtcpSourceInfo]
+    chunks: List[RtcpSourceInfo] = attr.ib(default=attr.Factory(list))
 
     def __bytes__(self) -> bytes:
         payload = b""
@@ -527,9 +527,9 @@ class RtcpSdesPacket:
 
 @attr.s
 class RtcpSrPacket:
-    ssrc = attr.ib()  # type: int
-    sender_info = attr.ib()  # type: RtcpSenderInfo
-    reports = attr.ib(default=attr.Factory(list))  # type: List[RtcpReceiverInfo]
+    ssrc: int = attr.ib()
+    sender_info: RtcpSenderInfo = attr.ib()
+    reports: List[RtcpReceiverInfo] = attr.ib(default=attr.Factory(list))
 
     def __bytes__(self) -> bytes:
         payload = pack("!L", self.ssrc)
@@ -626,7 +626,7 @@ class RtpPacket:
         self.sequence_number = sequence_number
         self.timestamp = timestamp
         self.ssrc = ssrc
-        self.csrc = []  # type: List[int]
+        self.csrc: List[int] = []
         self.extensions = HeaderExtensions()
         self.payload = payload
         self.padding_size = 0

--- a/src/aiortc/sdp.py
+++ b/src/aiortc/sdp.py
@@ -97,7 +97,7 @@ def ipaddress_to_sdp(addr: str) -> str:
 
 
 def parameters_from_sdp(sdp: str) -> OrderedDict:
-    parameters = OrderedDict()  # type: OrderedDict
+    parameters: OrderedDict = OrderedDict()
     for param in sdp.split(";"):
         if "=" in param:
             k, v = param.split("=", 1)
@@ -130,7 +130,7 @@ def parse_attr(line: str) -> Tuple[str, Optional[str]]:
 
 @attr.s
 class GroupDescription:
-    semantic = attr.ib()  # type: str
+    semantic: str = attr.ib()
     items = attr.ib()  # List[Union[int, str]]
 
     def __str__(self) -> str:
@@ -160,37 +160,37 @@ class MediaDescription:
         # rtp
         self.kind = kind
         self.port = port
-        self.host = None  # type: Optional[str]
+        self.host: Optional[str] = None
         self.profile = profile
-        self.direction = None  # type: Optional[str]
-        self.msid = None  # type: Optional[str]
+        self.direction: Optional[str] = None
+        self.msid: Optional[str] = None
 
         # rtcp
-        self.rtcp_port = None  # type: Optional[int]
-        self.rtcp_host = None  # type: Optional[str]
+        self.rtcp_port: Optional[int] = None
+        self.rtcp_host: Optional[str] = None
         self.rtcp_mux = False
 
         # ssrc
-        self.ssrc = []  # type: List[SsrcDescription]
-        self.ssrc_group = []  # type: List[GroupDescription]
+        self.ssrc: List[SsrcDescription] = []
+        self.ssrc_group: List[GroupDescription] = []
 
         # formats
         self.fmt = fmt
         self.rtp = RTCRtpParameters()
 
         # SCTP
-        self.sctpCapabilities = None  # type: Optional[RTCSctpCapabilities]
-        self.sctpmap = {}  # type: Dict[int, str]
-        self.sctp_port = None  # type: Optional[int]
+        self.sctpCapabilities: Optional[RTCSctpCapabilities] = None
+        self.sctpmap: Dict[int, str] = {}
+        self.sctp_port: Optional[int] = None
 
         # DTLS
-        self.dtls = None  # type: Optional[RTCDtlsParameters]
+        self.dtls: Optional[RTCDtlsParameters] = None
 
         # ICE
         self.ice = RTCIceParameters()
-        self.ice_candidates = []  # type: List[RTCIceCandidate]
+        self.ice_candidates: List[RTCIceCandidate] = []
         self.ice_candidates_complete = False
-        self.ice_options = None  # type: Optional[str]
+        self.ice_options: Optional[str] = None
 
     def __str__(self) -> str:
         lines = []
@@ -272,18 +272,18 @@ class MediaDescription:
 class SessionDescription:
     def __init__(self) -> None:
         self.version = 0
-        self.origin = None  # type: Optional[str]
+        self.origin: Optional[str] = None
         self.name = "-"
         self.time = "0 0"
-        self.host = None  # type: Optional[str]
-        self.group = []  # type: List[GroupDescription]
-        self.msid_semantic = []  # type: List[GroupDescription]
-        self.media = []  # type: List[MediaDescription]
-        self.type = None  # type: str
+        self.host: Optional[str] = None
+        self.group: List[GroupDescription] = []
+        self.msid_semantic: List[GroupDescription] = []
+        self.media: List[MediaDescription] = []
+        self.type: Optional[str] = None
 
     @classmethod
     def parse(cls, sdp: str):
-        current_media = None  # type: Optional[MediaDescription]
+        current_media: Optional[MediaDescription] = None
         dtls_fingerprints = []
         ice_lite = False
         ice_options = None
@@ -330,7 +330,7 @@ class SessionDescription:
             # check payload types are valid
             kind = m.group(1)
             fmt = m.group(4).split()
-            fmt_int = None  # type: Optional[List[int]]
+            fmt_int: Optional[List[int]] = None
             if kind in ["audio", "video"]:
                 fmt_int = [int(x) for x in fmt]
                 for pt in fmt_int:

--- a/src/aiortc/stats.py
+++ b/src/aiortc/stats.py
@@ -1,3 +1,5 @@
+import datetime
+
 import attr
 
 
@@ -7,31 +9,31 @@ class RTCStats:
     Base class for statistics.
     """
 
-    timestamp = attr.ib()
+    timestamp: datetime.datetime = attr.ib()
     "The timestamp associated with this object."
-    type = attr.ib()
-    id = attr.ib()
+    type: str = attr.ib()
+    id: str = attr.ib()
 
 
 @attr.s
 class RTCRtpStreamStats(RTCStats):
-    ssrc = attr.ib()
-    kind = attr.ib()
-    transportId = attr.ib()
+    ssrc: int = attr.ib()
+    kind: str = attr.ib()
+    transportId: str = attr.ib()
 
 
 @attr.s
 class RTCReceivedRtpStreamStats(RTCRtpStreamStats):
-    packetsReceived = attr.ib()
-    packetsLost = attr.ib()
-    jitter = attr.ib()
+    packetsReceived: int = attr.ib()
+    packetsLost: int = attr.ib()
+    jitter: int = attr.ib()
 
 
 @attr.s
 class RTCSentRtpStreamStats(RTCRtpStreamStats):
-    packetsSent = attr.ib()
+    packetsSent: int = attr.ib()
     "Total number of RTP packets sent for this SSRC."
-    bytesSent = attr.ib()
+    bytesSent: int = attr.ib()
     "Total number of bytes sent for this SSRC."
 
 
@@ -52,8 +54,8 @@ class RTCRemoteInboundRtpStreamStats(RTCReceivedRtpStreamStats):
     endpoint's measurement metrics for a particular incoming RTP stream.
     """
 
-    roundTripTime = attr.ib()
-    fractionLost = attr.ib()
+    roundTripTime: float = attr.ib()
+    fractionLost: float = attr.ib()
 
 
 @attr.s
@@ -63,7 +65,7 @@ class RTCOutboundRtpStreamStats(RTCSentRtpStreamStats):
     metrics for the outgoing RTP stream.
     """
 
-    trackId = attr.ib(type=str)
+    trackId: str = attr.ib()
 
 
 @attr.s
@@ -73,22 +75,22 @@ class RTCRemoteOutboundRtpStreamStats(RTCSentRtpStreamStats):
     endpoint's measurement metrics for its outgoing RTP stream.
     """
 
-    remoteTimestamp = attr.ib(default=None)
+    remoteTimestamp: datetime.datetime = attr.ib(default=None)
 
 
 @attr.s
 class RTCTransportStats(RTCStats):
-    packetsSent = attr.ib()  # type: int
+    packetsSent: int = attr.ib()
     "Total number of packets sent over this transport."
-    packetsReceived = attr.ib()  # type: int
+    packetsReceived: int = attr.ib()
     "Total number of packets received over this transport."
-    bytesSent = attr.ib()  # type: int
+    bytesSent: int = attr.ib()
     "Total number of bytes sent over this transport."
-    bytesReceived = attr.ib()  # type: int
+    bytesReceived: int = attr.ib()
     "Total number of bytes received over this transport."
-    iceRole = attr.ib()  # type: str
+    iceRole: str = attr.ib()
     "The current value of :attr:`RTCIceTransport.role`."
-    dtlsState = attr.ib()  # type: str
+    dtlsState: str = attr.ib()
     "The current value of :attr:`RTCDtlsTransport.state`."
 
 


### PR DESCRIPTION
What was done in the scope of this pull request:
1. Rewrite all `type comments` into `type annotations`.
2. Edit code due to mypy errors.

There is a problem with `aiortc.rtcsctptransport:Chunk` class. In this class `body` attribute defined as an instance attribute but in delivered classes it defined using `property` due to it mypy throws an error. In order to suppress errors `# type: ignore` was used on the `body` property declaration.

Also, there is problem with `aiorc.rtcsctptransport:RTCSctpTransport`. `_send` method dynamically add attributes to `DataChunk` instance, due to it mypy throws an error, suppress them using `no_type_check` decorator.

I think we should resolve this problem in the future.