### PR TITLE
Fixes #283

### DIFF
--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -280,10 +280,9 @@ class MediaPlayer:
             self.__thread_quit.set()
             self.__thread.join()
             self.__thread = None
-
-        if self.__container:
-            self.__container.close()
-            self.__container = None
+            if self.__container:
+                self.__container.close()
+                self.__container = None
 
     def __log_debug(self, msg, *args):
         logger.debug(f"player(%s) {msg}", self.__container.name, *args)

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -287,7 +287,7 @@ class RTCRtpSender:
         sequence_number = random16()
         timestamp_origin = random32()
         try:
-            while self.__rtp_exited.is_set is False:
+            while self.__rtp_exited.is_set() is False:
                 if not self.__track:
                     await asyncio.sleep(0.02)
                     continue
@@ -337,7 +337,7 @@ class RTCRtpSender:
         self.__log_debug("- RTCP started")
 
         try:
-            while self.__rtcp_exited.is_set is False:
+            while self.__rtcp_exited.is_set() is False:
                 # The interval between RTCP packets is varied randomly over the
                 # range [0.5, 1.5] times the calculated interval.
                 await asyncio.sleep(0.5 + random.random())

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -4351,6 +4351,7 @@ a=fmtp:98 apt=97
     def test_audio_live_nostoptracks(self):
         audioPlayer = MediaPlayer("none:0", "avfoundation")
         self.audio_video(audioPlayer.audio, None, False)
+        audioPlayer.audio.stop()
 
     def test_video_live_stoptracks(self):
         videoPlayer = MediaPlayer(
@@ -4367,6 +4368,7 @@ a=fmtp:98 apt=97
             {"framerate": "30", "video_size": "640x480"}
         )
         self.audio_video(None, videoPlayer.video, False)
+        videoPlayer.video.stop()
 
     def test_audio_video_live_stoptracks(self):
         audioPlayer = MediaPlayer("none:0", "avfoundation")
@@ -4385,22 +4387,30 @@ a=fmtp:98 apt=97
             {"framerate": "30", "video_size": "640x480"}
         )
         self.audio_video(audioPlayer.audio, videoPlayer.video, False)
+        audioPlayer.audio.stop()
+        videoPlayer.video.stop()
 
     def test_audio_cold_stoptracks(self):
         player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
         self.audio_video(player.audio, None, True)
+        player.video.stop()
 
     def test_audio_cold_nostoptracks(self):
         player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
         self.audio_video(player.audio, None, False)
+        player.audio.stop()
+        player.video.stop()
 
     def test_video_cold_stoptracks(self):
         player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
         self.audio_video(None, player.video, True)
+        player.audio.stop()
 
     def test_video_cold_nostoptracks(self):
         player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
         self.audio_video(None, player.video, False)
+        player.audio.stop()
+        player.video.stop()
 
     def test_audio_video_cold_stoptracks(self):
         player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
@@ -4409,3 +4419,5 @@ a=fmtp:98 apt=97
     def test_audio_video_cold_nostoptracks(self):
         player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
         self.audio_video(player.audio, player.video, False)
+        player.audio.stop()
+        player.video.stop()

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -4236,6 +4236,29 @@ a=fmtp:98 apt=97
             ],
         )
 
+    def create_player(self, type, audio, video):
+        player = None
+        if type == "device":
+            # NOTE: Only ready for MacOS!
+            if audio is True:
+                player = MediaPlayer("none:0", "avfoundation")
+            elif video is True:
+                player = MediaPlayer(
+                    "default:none",
+                    "avfoundation",
+                    {"framerate": "30", "video_size": "640x480"}
+                )
+        else:
+            player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
+
+        return player
+
+    def stop_player(self, player):
+        if player.audio:
+            player.audio.stop()
+        if player.video:
+            player.video.stop()
+
     def audio_video(self, audioTrack, videoTrack, stopTracks):
         pc1 = RTCPeerConnection()
         pc2 = RTCPeerConnection()
@@ -4345,79 +4368,58 @@ a=fmtp:98 apt=97
         )
 
     def test_audio_live_stoptracks(self):
-        audioPlayer = MediaPlayer("none:0", "avfoundation")
+        audioPlayer = self.create_player("device", True, False)
         self.audio_video(audioPlayer.audio, None, True)
 
     def test_audio_live_nostoptracks(self):
-        audioPlayer = MediaPlayer("none:0", "avfoundation")
+        audioPlayer = self.create_player("device", True, False)
         self.audio_video(audioPlayer.audio, None, False)
-        audioPlayer.audio.stop()
+        self.stop_player(audioPlayer)
 
     def test_video_live_stoptracks(self):
-        videoPlayer = MediaPlayer(
-            "default:none",
-            "avfoundation",
-            {"framerate": "30", "video_size": "640x480"}
-        )
+        videoPlayer = self.create_player("device", False, True)
         self.audio_video(None, videoPlayer.video, True)
 
     def test_video_live_nostoptracks(self):
-        videoPlayer = MediaPlayer(
-            "default:none",
-            "avfoundation",
-            {"framerate": "30", "video_size": "640x480"}
-        )
+        videoPlayer = self.create_player("device", False, True)
         self.audio_video(None, videoPlayer.video, False)
-        videoPlayer.video.stop()
+        self.stop_player(videoPlayer)
 
     def test_audio_video_live_stoptracks(self):
-        audioPlayer = MediaPlayer("none:0", "avfoundation")
-        videoPlayer = MediaPlayer(
-            "default:none",
-            "avfoundation",
-            {"framerate": "30", "video_size": "640x480"}
-        )
+        audioPlayer = self.create_player("device", True, False)
+        videoPlayer = self.create_player("device", False, True)
         self.audio_video(audioPlayer.audio, videoPlayer.video, True)
 
     def test_audio_video_live_nostoptracks(self):
-        audioPlayer = MediaPlayer("none:0", "avfoundation")
-        videoPlayer = MediaPlayer(
-            "default:none",
-            "avfoundation",
-            {"framerate": "30", "video_size": "640x480"}
-        )
+        audioPlayer = self.create_player("device", True, False)
+        videoPlayer = self.create_player("device", False, True)
         self.audio_video(audioPlayer.audio, videoPlayer.video, False)
-        audioPlayer.audio.stop()
-        videoPlayer.video.stop()
+        self.stop_player(audioPlayer)
+        self.stop_player(videoPlayer)
 
     def test_audio_cold_stoptracks(self):
-        player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
+        player = self.create_player("url", True, True)
         self.audio_video(player.audio, None, True)
-        player.video.stop()
 
     def test_audio_cold_nostoptracks(self):
-        player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
+        player = self.create_player("url", True, True)
         self.audio_video(player.audio, None, False)
-        player.audio.stop()
-        player.video.stop()
+        self.stop_player(player)
 
     def test_video_cold_stoptracks(self):
-        player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
+        player = self.create_player("url", True, True)
         self.audio_video(None, player.video, True)
-        player.audio.stop()
 
     def test_video_cold_nostoptracks(self):
-        player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
+        player = self.create_player("url", True, True)
         self.audio_video(None, player.video, False)
-        player.audio.stop()
-        player.video.stop()
+        self.stop_player(player)
 
     def test_audio_video_cold_stoptracks(self):
-        player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
+        player = self.create_player("url", True, True)
         self.audio_video(player.audio, player.video, True)
 
     def test_audio_video_cold_nostoptracks(self):
-        player = MediaPlayer("http://commondatastorage.googleapis.com/gtv-videos-bucket/sample/BigBuckBunny.mp4")
+        player = self.create_player("url", True, True)
         self.audio_video(player.audio, player.video, False)
-        player.audio.stop()
-        player.video.stop()
+        self.stop_player(player)


### PR DESCRIPTION
 - MediaPlayer: close av container when there are no remaining tracks
 - RTCRtpSender: don't close MediaStreamTrack on close()
 - RTCRtpSender: close() stops sending RTP and RTCP