### PR TITLE
[media player] only close container once all tracks are stopped

### DIFF
--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -275,13 +275,14 @@ class MediaPlayer:
 
     def _stop(self, track):
         self.__started.discard(track)
+
         if not self.__started and self.__thread is not None:
             self.__log_debug("Stopping worker thread")
             self.__thread_quit.set()
             self.__thread.join()
             self.__thread = None
 
-        if self.__container:
+        if not self.__started and self.__container is not None:
             self.__container.close()
             self.__container = None
 

--- a/tests/codecs.py
+++ b/tests/codecs.py
@@ -9,18 +9,28 @@ from aiortc.mediastreams import AUDIO_PTIME, VIDEO_TIME_BASE
 
 
 class CodecTestCase(TestCase):
+    def create_audio_frame(self, samples, pts, layout="mono", sample_rate=48000):
+        frame = AudioFrame(format="s16", layout=layout, samples=samples)
+        for p in frame.planes:
+            p.update(bytes(p.buffer_size))
+        frame.pts = pts
+        frame.sample_rate = sample_rate
+        frame.time_base = fractions.Fraction(1, sample_rate)
+        return frame
+
     def create_audio_frames(self, layout, sample_rate, count):
         frames = []
         timestamp = 0
         samples_per_frame = int(AUDIO_PTIME * sample_rate)
         for i in range(count):
-            frame = AudioFrame(format="s16", layout=layout, samples=samples_per_frame)
-            for p in frame.planes:
-                p.update(bytes(p.buffer_size))
-            frame.pts = timestamp
-            frame.sample_rate = sample_rate
-            frame.time_base = fractions.Fraction(1, sample_rate)
-            frames.append(frame)
+            frames.append(
+                self.create_audio_frame(
+                    samples=samples_per_frame,
+                    pts=timestamp,
+                    layout=layout,
+                    sample_rate=sample_rate,
+                )
+            )
             timestamp += samples_per_frame
         return frames
 


### PR DESCRIPTION
When reading a file with multiple tracks, we must take care to only
close the container once the player thread has shut down. This thread is
only shut down once all tracks are stopped.

Fixes: #237, #274