### PR TITLE
[signaling] add an explicit BYE object

### DIFF
--- a/examples/apprtc/apprtc.py
+++ b/examples/apprtc/apprtc.py
@@ -14,7 +14,7 @@ from aiortc import (
     VideoStreamTrack,
 )
 from aiortc.contrib.media import MediaBlackhole, MediaPlayer, MediaRecorder
-from aiortc.contrib.signaling import ApprtcSignaling
+from aiortc.contrib.signaling import BYE, ApprtcSignaling
 
 ROOT = os.path.dirname(__file__)
 PHOTO_PATH = os.path.join(ROOT, "photo.jpg")
@@ -84,7 +84,7 @@ async def run(pc, player, recorder, signaling):
                 await signaling.send(pc.localDescription)
         elif isinstance(obj, RTCIceCandidate):
             pc.addIceCandidate(obj)
-        elif obj is None:
+        elif obj is BYE:
             print("Exiting")
             break
 

--- a/examples/datachannel-cli/cli.py
+++ b/examples/datachannel-cli/cli.py
@@ -4,7 +4,7 @@ import logging
 import time
 
 from aiortc import RTCIceCandidate, RTCPeerConnection, RTCSessionDescription
-from aiortc.contrib.signaling import add_signaling_arguments, create_signaling
+from aiortc.contrib.signaling import BYE, add_signaling_arguments, create_signaling
 
 
 def channel_log(channel, t, message):
@@ -29,7 +29,7 @@ async def consume_signaling(pc, signaling):
                 await signaling.send(pc.localDescription)
         elif isinstance(obj, RTCIceCandidate):
             pc.addIceCandidate(obj)
-        elif obj is None:
+        elif obj is BYE:
             print("Exiting")
             break
 

--- a/examples/datachannel-filexfer/filexfer.py
+++ b/examples/datachannel-filexfer/filexfer.py
@@ -4,7 +4,7 @@ import logging
 import time
 
 from aiortc import RTCIceCandidate, RTCPeerConnection, RTCSessionDescription
-from aiortc.contrib.signaling import add_signaling_arguments, create_signaling
+from aiortc.contrib.signaling import BYE, add_signaling_arguments, create_signaling
 
 # optional, for better performance
 try:
@@ -26,7 +26,7 @@ async def consume_signaling(pc, signaling):
                 await signaling.send(pc.localDescription)
         elif isinstance(obj, RTCIceCandidate):
             pc.addIceCandidate(obj)
-        elif obj is None:
+        elif obj is BYE:
             print("Exiting")
             break
 

--- a/examples/datachannel-vpn/vpn.py
+++ b/examples/datachannel-vpn/vpn.py
@@ -5,7 +5,7 @@ import logging
 import tuntap
 
 from aiortc import RTCIceCandidate, RTCPeerConnection, RTCSessionDescription
-from aiortc.contrib.signaling import add_signaling_arguments, create_signaling
+from aiortc.contrib.signaling import BYE, add_signaling_arguments, create_signaling
 
 logger = logging.Logger("vpn")
 
@@ -27,7 +27,7 @@ async def consume_signaling(pc, signaling):
                 await signaling.send(pc.localDescription)
         elif isinstance(obj, RTCIceCandidate):
             pc.addIceCandidate(obj)
-        elif obj is None:
+        elif obj is BYE:
             print("Exiting")
             break
 

--- a/examples/videostream-cli/cli.py
+++ b/examples/videostream-cli/cli.py
@@ -14,7 +14,7 @@ from aiortc import (
     VideoStreamTrack,
 )
 from aiortc.contrib.media import MediaBlackhole, MediaPlayer, MediaRecorder
-from aiortc.contrib.signaling import add_signaling_arguments, create_signaling
+from aiortc.contrib.signaling import BYE, add_signaling_arguments, create_signaling
 
 
 class FlagVideoStreamTrack(VideoStreamTrack):
@@ -116,7 +116,7 @@ async def run(pc, player, recorder, signaling, role):
                 await signaling.send(pc.localDescription)
         elif isinstance(obj, RTCIceCandidate):
             pc.addIceCandidate(obj)
-        elif obj is None:
+        elif obj is BYE:
             print("Exiting")
             break
 

--- a/tests/test_contrib_signaling.py
+++ b/tests/test_contrib_signaling.py
@@ -4,6 +4,7 @@ from unittest import TestCase
 
 from aiortc import RTCIceCandidate, RTCSessionDescription
 from aiortc.contrib.signaling import (
+    BYE,
     add_signaling_arguments,
     create_signaling,
     object_from_string,
@@ -232,10 +233,10 @@ class SignalingTest(TestCase):
 
 class SignalingUtilsTest(TestCase):
     def test_bye_from_string(self):
-        self.assertEqual(object_from_string('{"type": "bye"}'), None)
+        self.assertEqual(object_from_string('{"type": "bye"}'), BYE)
 
     def test_bye_to_string(self):
-        self.assertEqual(object_to_string(None), '{"type": "bye"}')
+        self.assertEqual(object_to_string(BYE), '{"type": "bye"}')
 
     def test_candidate_from_string(self):
         candidate = object_from_string(


### PR DESCRIPTION
Using None as a "bye" magic value makes it impossible to ignore unknown
messages, for example empty "candidate" messages from appr.tc.