### PR TITLE
[dtls] drop support for OpenSSL < 1.0.2

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -85,7 +85,12 @@ Requirements
 ------------
 
 In addition to aiortc's Python dependencies you need a couple of libraries
-installed on your system for media codecs. FFmpeg 3.2 or greater is required.
+installed on your system for media codecs:
+
+- OpenSSL 1.0.2 or greater
+- FFmpeg 4.0 or greater
+- LibVPX for video encoding / decoding
+- Opus for audio encoding / decoding
 
 Linux
 .....


### PR DESCRIPTION
Some distros:

- Debian Stretch (released in 2017) carries OpenSSL 1.1.0
- Ubuntu Xenial (released in 2016) carries OpenSSL 1.0.2g