### PR TITLE
Mediaplayer deadlock fix

### DIFF
--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -326,9 +326,8 @@ class RTCRtpSender:
         except (asyncio.CancelledError, ConnectionError, MediaStreamError):
             pass
 
-        # stop track
+        # unreference the track
         if self.__track:
-            self.__track.stop()
             self.__track = None
 
         self.__log_debug("- RTP finished")


### PR DESCRIPTION
* MediaPlayer deadlock fix when MediaStreamTrack is stopped before stopping the `RTCRtpSender` to which the track is attached
* Don't stop track on `RTCRtpSender.stop()`