### PR TITLE
[media player] ensure self._player is not None before using it

### DIFF
--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -171,7 +171,11 @@ class PlayerStreamTrack(MediaStreamTrack):
         frame_time = frame.time
 
         # control playback rate
-        if self._player._throttle_playback and frame_time is not None:
+        if (
+            self._player is not None
+            and self._player._throttle_playback
+            and frame_time is not None
+        ):
             if self._start is None:
                 self._start = time.time() - frame_time
             else:


### PR DESCRIPTION
self._player may have been cleared by a call to track.stop() while we
were waiting for a frame, so check it is not None before using it.

Fixes: #283