### PR TITLE
[sctp] fix call to debug logging

### DIFF
--- a/src/aiortc/rtcsctptransport.py
+++ b/src/aiortc/rtcsctptransport.py
@@ -1342,7 +1342,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
                 break
         chunk.params.append((param_type, bytes(param)))
 
-        self.__log_debug(f">> {param}", param)
+        self.__log_debug(f">> {param}")
         await self._send_chunk(chunk)
 
     async def _send_sack(self):


### PR DESCRIPTION
Commit 3da949da659ad3e26b63903803570bd135c6235b switched to f-string,
but the "param" argument was still being passed, resulting in a logging
error.