### PR TITLE
Don't use f-strings to format log messages

### DIFF
--- a/src/aiortc/rtcdatachannel.py
+++ b/src/aiortc/rtcdatachannel.py
@@ -199,7 +199,7 @@ class RTCDataChannel(AsyncIOEventEmitter):
 
     def _setReadyState(self, state: str) -> None:
         if state != self.__readyState:
-            self.__log_debug(f"- {self.__readyState} -> {state}")
+            self.__log_debug("- %s -> %s", self.__readyState, state)
             self.__readyState = state
 
             if state == "open":

--- a/src/aiortc/rtcdtlstransport.py
+++ b/src/aiortc/rtcdtlstransport.py
@@ -446,9 +446,9 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
                 if error == lib.SSL_ERROR_WANT_READ:
                     await self._recv_next()
                 else:
-                    self.__log_debug(f"x DTLS handshake failed (error {error})")
+                    self.__log_debug("x DTLS handshake failed (error %d)", error)
                     for info in get_error_queue():
-                        self.__log_debug(f"x {':'.join(info)}")
+                        self.__log_debug("x %s", ":".join(info))
                     self._set_state(State.FAILED)
                     return
         except ConnectionError:
@@ -558,7 +558,7 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
         try:
             packets = RtcpPacket.parse(data)
         except ValueError as exc:
-            self.__log_debug(f"x RTCP parsing failed: {exc}")
+            self.__log_debug("x RTCP parsing failed: %s", exc)
             return
 
         for packet in packets:
@@ -570,7 +570,7 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
         try:
             packet = RtpPacket.parse(data, self._rtp_header_extensions_map)
         except ValueError as exc:
-            self.__log_debug(f"x RTP parsing failed: {exc}")
+            self.__log_debug("x RTP parsing failed: %s", exc)
             return
 
         # route RTP packet
@@ -625,7 +625,7 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
                     data = self._rx_srtp.unprotect(data)
                     await self._handle_rtp_data(data, arrival_time_ms=arrival_time_ms)
             except pylibsrtp.Error as exc:
-                self.__log_debug(f"x SRTP unprotect failed: {exc}")
+                self.__log_debug("x SRTP unprotect failed: %s", exc)
 
     def _register_data_receiver(self, receiver) -> None:
         assert self._data_receiver is None
@@ -674,7 +674,7 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
 
     def _set_state(self, state: State) -> None:
         if state != self._state:
-            self.__log_debug(f"- {self._state} -> {state}")
+            self.__log_debug("- %s -> %s", self._state, state)
             self._state = state
             self.emit("statechange")
 

--- a/src/aiortc/rtcicetransport.py
+++ b/src/aiortc/rtcicetransport.py
@@ -347,7 +347,7 @@ class RTCIceTransport(AsyncIOEventEmitter):
 
     def __setState(self, state: str) -> None:
         if state != self.__state:
-            self.__log_debug(f"- {self.__state} -> {state}")
+            self.__log_debug("- %s -> %s", self.__state, state)
             self.__state = state
             self.emit("statechange")
 

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -385,7 +385,7 @@ class RTCRtpReceiver:
         self.__stop_decoder()
 
     async def _handle_rtcp_packet(self, packet: AnyRtcpPacket) -> None:
-        self.__log_debug(f"< {packet}")
+        self.__log_debug("< %s", packet)
 
         if isinstance(packet, RtcpSrPacket):
             self.__stats.add(
@@ -418,7 +418,7 @@ class RTCRtpReceiver:
         """
         Handle an incoming RTP packet.
         """
-        self.__log_debug(f"< {packet}")
+        self.__log_debug("< %s", packet)
 
         # feed bitrate estimator
         if self.__remote_bitrate_estimator is not None:
@@ -446,7 +446,7 @@ class RTCRtpReceiver:
         codec = self.__codecs.get(packet.payload_type)
         if codec is None:
             self.__log_debug(
-                f"x RTP packet with unknown payload type {packet.payload_type}"
+                "x RTP packet with unknown payload type %d", packet.payload_type
             )
             return
 
@@ -459,7 +459,7 @@ class RTCRtpReceiver:
         if is_rtx(codec):
             original_ssrc = self.__rtx_ssrc.get(packet.ssrc)
             if original_ssrc is None:
-                self.__log_debug(f"x RTX packet from unknown SSRC {packet.ssrc}")
+                self.__log_debug("x RTX packet from unknown SSRC %d", packet.ssrc)
                 return
 
             if len(packet.payload) < 2:
@@ -483,7 +483,7 @@ class RTCRtpReceiver:
             else:
                 packet._data = b""  # type: ignore
         except ValueError as exc:
-            self.__log_debug(f"x RTP payload parsing failed: {exc}")
+            self.__log_debug("x RTP payload parsing failed: %s", exc)
             return
 
         # try to re-assemble encoded frame
@@ -539,7 +539,7 @@ class RTCRtpReceiver:
         self.__rtcp_exited.set()
 
     async def _send_rtcp(self, packet) -> None:
-        self.__log_debug(f"> {packet}")
+        self.__log_debug("> %s", packet)
         try:
             await self.transport._send_rtp(bytes(packet))
         except ConnectionError:

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -236,7 +236,7 @@ class RTCRtpSender:
                 bitrate, ssrcs = unpack_remb_fci(packet.fci)
                 if self._ssrc in ssrcs:
                     self.__log_debug(
-                        f"- receiver estimated maximum bitrate {bitrate} bps"
+                        "- receiver estimated maximum bitrate %d bps", bitrate
                     )
                     if self.__encoder and hasattr(self.__encoder, "target_bitrate"):
                         self.__encoder.target_bitrate = bitrate
@@ -271,7 +271,7 @@ class RTCRtpSender:
                 )
                 self.__rtx_sequence_number = uint16_add(self.__rtx_sequence_number, 1)
 
-            self.__log_debug(f"> {packet}")
+            self.__log_debug("> %s", packet)
             packet_bytes = packet.serialize(self.__rtp_header_extensions_map)
             await self.transport._send_rtp(packet_bytes)
 
@@ -312,7 +312,7 @@ class RTCRtpSender:
                     packet.extensions.mid = self.__mid
 
                     # send packet
-                    self.__log_debug(f"> {packet}")
+                    self.__log_debug("> %s", packet)
                     self.__rtp_history[
                         packet.sequence_number % RTP_HISTORY_SIZE
                     ] = packet
@@ -390,7 +390,7 @@ class RTCRtpSender:
     async def _send_rtcp(self, packets: List[AnyRtcpPacket]) -> None:
         payload = b""
         for packet in packets:
-            self.__log_debug(f"> {packet}")
+            self.__log_debug("> %s", packet)
             payload += bytes(packet)
 
         try:

--- a/src/aiortc/rtcsctptransport.py
+++ b/src/aiortc/rtcsctptransport.py
@@ -832,7 +832,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
         # verify tag
         if verification_tag != expected_tag:
             self.__log_debug(
-                f"Bad verification tag {verification_tag} vs {expected_tag}"
+                "Bad verification tag %d vs %d", verification_tag, expected_tag
             )
             return
 
@@ -913,7 +913,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
         """
         Handle an incoming chunk.
         """
-        self.__log_debug(f"< {chunk}")
+        self.__log_debug("< %s", chunk)
 
         # common
         if isinstance(chunk, DataChunk):
@@ -960,8 +960,9 @@ class RTCSctpTransport(AsyncIOEventEmitter):
             self._get_extensions(chunk.params)
 
             self.__log_debug(
-                f"- Peer supports {chunk.outbound_streams} outbound streams, "
-                f"{chunk.inbound_streams} max inbound streams"
+                "- Peer supports %d outbound streams, %d max inbound streams",
+                chunk.outbound_streams,
+                chunk.inbound_streams,
             )
             self._inbound_streams_count = min(
                 chunk.outbound_streams, self._inbound_streams_max
@@ -1021,8 +1022,9 @@ class RTCSctpTransport(AsyncIOEventEmitter):
             self._get_extensions(chunk.params)
 
             self.__log_debug(
-                f"- Peer supports {chunk.outbound_streams} outbound streams, "
-                f"{chunk.inbound_streams} max inbound streams"
+                "- Peer supports %d outbound streams, %d max inbound streams",
+                chunk.outbound_streams,
+                chunk.inbound_streams,
             )
             self._inbound_streams_count = min(
                 chunk.outbound_streams, self._inbound_streams_max
@@ -1219,7 +1221,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
         """
         Handle a RE-CONFIG parameter.
         """
-        self.__log_debug(f"<< {param}")
+        self.__log_debug("<< %s", param)
 
         if isinstance(param, StreamResetOutgoingParam):
             # mark closed inbound streams
@@ -1324,7 +1326,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
         """
         Transmit a chunk (no bundling for now).
         """
-        self.__log_debug(f"> {chunk}")
+        self.__log_debug("> %s", chunk)
         await self.__transport._send_data(
             serialize_packet(
                 self._local_port,
@@ -1342,7 +1344,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
                 break
         chunk.params.append((param_type, bytes(param)))
 
-        self.__log_debug(f">> {param}")
+        self.__log_debug(">> %s", param)
         await self._send_chunk(chunk)
 
     async def _send_sack(self):
@@ -1375,7 +1377,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
         Transition the SCTP association to a new state.
         """
         if state != self._association_state:
-            self.__log_debug(f"- {self._association_state} -> {state}")
+            self.__log_debug("- %s -> %s", self._association_state, state)
             self._association_state = state
 
         if state == self.State.ESTABLISHED:
@@ -1402,7 +1404,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
 
     def _t1_cancel(self) -> None:
         if self._t1_handle is not None:
-            self.__log_debug(f"- T1({chunk_type(self._t1_chunk)}) cancel")
+            self.__log_debug("- T1(%s) cancel", chunk_type(self._t1_chunk))
             self._t1_handle.cancel()
             self._t1_handle = None
             self._t1_chunk = None
@@ -1411,7 +1413,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
         self._t1_failures += 1
         self._t1_handle = None
         self.__log_debug(
-            f"x T1({chunk_type(self._t1_chunk)}) expired {self._t1_failures}"
+            "x T1(%s) expired %d", chunk_type(self._t1_chunk), self._t1_failures
         )
         if self._t1_failures > SCTP_MAX_INIT_RETRANS:
             self._set_state(self.State.CLOSED)
@@ -1423,12 +1425,12 @@ class RTCSctpTransport(AsyncIOEventEmitter):
         assert self._t1_handle is None
         self._t1_chunk = chunk
         self._t1_failures = 0
-        self.__log_debug(f"- T1({chunk_type(self._t1_chunk)}) start")
+        self.__log_debug("- T1(%s) start", chunk_type(self._t1_chunk))
         self._t1_handle = self._loop.call_later(self._rto, self._t1_expired)
 
     def _t2_cancel(self) -> None:
         if self._t2_handle is not None:
-            self.__log_debug(f"- T2({chunk_type(self._t2_chunk)}) cancel")
+            self.__log_debug("- T2(%s) cancel", chunk_type(self._t2_chunk))
             self._t2_handle.cancel()
             self._t2_handle = None
             self._t2_chunk = None
@@ -1437,7 +1439,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
         self._t2_failures += 1
         self._t2_handle = None
         self.__log_debug(
-            f"x T2({chunk_type(self._t2_chunk)}) expired {self._t2_failures}"
+            "x T2(%s) expired %d", chunk_type(self._t2_chunk), self._t2_failures
         )
         if self._t2_failures > SCTP_MAX_ASSOCIATION_RETRANS:
             self._set_state(self.State.CLOSED)
@@ -1449,7 +1451,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
         assert self._t2_handle is None
         self._t2_chunk = chunk
         self._t2_failures = 0
-        self.__log_debug(f"- T2({chunk_type(self._t2_chunk)}) start")
+        self.__log_debug("- T2(%s) start", chunk_type(self._t2_chunk))
         self._t2_handle = self._loop.call_later(self._rto, self._t2_expired)
 
     @no_type_check


### PR DESCRIPTION
Replace f-strings from `__debug_log` function call.
This pull request related to #262.