### PR TITLE
Allow custom bind address in examples

### DIFF
--- a/examples/server/server.py
+++ b/examples/server/server.py
@@ -195,6 +195,7 @@ if __name__ == "__main__":
             host = args.bind
             port = args.port
     else:
+        host = "0.0.0.0"
         port = args.port
 
     if args.verbose:

--- a/examples/server/server.py
+++ b/examples/server/server.py
@@ -180,23 +180,15 @@ if __name__ == "__main__":
     )
     parser.add_argument("--cert-file", help="SSL certificate file (for HTTPS)")
     parser.add_argument("--key-file", help="SSL key file (for HTTPS)")
-    parser.add_argument("--bind", default="0.0.0.0")
+    parser.add_argument(
+        "--host", default="0.0.0.0", help="Host for HTTP server (default: 0.0.0.0)"
+    )
     parser.add_argument(
         "--port", type=int, default=8080, help="Port for HTTP server (default: 8080)"
     )
     parser.add_argument("--verbose", "-v", action="count")
     parser.add_argument("--write-audio", help="Write received audio to a file")
     args = parser.parse_args()
-
-    if args.bind:
-        try:
-            host, port = args.bind.split(":", 1)
-        except ValueError:
-            host = args.bind
-            port = args.port
-    else:
-        host = "0.0.0.0"
-        port = args.port
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
@@ -214,4 +206,4 @@ if __name__ == "__main__":
     app.router.add_get("/", index)
     app.router.add_get("/client.js", javascript)
     app.router.add_post("/offer", offer)
-    web.run_app(app, access_log=None, host=host, port=port, ssl_context=ssl_context)
+    web.run_app(app, access_log=None, host=args.host, port=args.port, ssl_context=ssl_context)

--- a/examples/server/server.py
+++ b/examples/server/server.py
@@ -180,12 +180,22 @@ if __name__ == "__main__":
     )
     parser.add_argument("--cert-file", help="SSL certificate file (for HTTPS)")
     parser.add_argument("--key-file", help="SSL key file (for HTTPS)")
+    parser.add_argument("--bind", default="0.0.0.0")
     parser.add_argument(
         "--port", type=int, default=8080, help="Port for HTTP server (default: 8080)"
     )
     parser.add_argument("--verbose", "-v", action="count")
     parser.add_argument("--write-audio", help="Write received audio to a file")
     args = parser.parse_args()
+
+    if args.bind:
+        try:
+            host, port = args.bind.split(":", 1)
+        except ValueError:
+            host = args.bind
+            port = args.port
+    else:
+        port = args.port
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
@@ -203,4 +213,4 @@ if __name__ == "__main__":
     app.router.add_get("/", index)
     app.router.add_get("/client.js", javascript)
     app.router.add_post("/offer", offer)
-    web.run_app(app, access_log=None, port=args.port, ssl_context=ssl_context)
+    web.run_app(app, access_log=None, host=host, port=port, ssl_context=ssl_context)

--- a/examples/server/server.py
+++ b/examples/server/server.py
@@ -206,4 +206,6 @@ if __name__ == "__main__":
     app.router.add_get("/", index)
     app.router.add_get("/client.js", javascript)
     app.router.add_post("/offer", offer)
-    web.run_app(app, access_log=None, host=args.host, port=args.port, ssl_context=ssl_context)
+    web.run_app(
+        app, access_log=None, host=args.host, port=args.port, ssl_context=ssl_context
+    )

--- a/examples/webcam/webcam.py
+++ b/examples/webcam/webcam.py
@@ -81,11 +81,21 @@ if __name__ == "__main__":
     parser.add_argument("--cert-file", help="SSL certificate file (for HTTPS)")
     parser.add_argument("--key-file", help="SSL key file (for HTTPS)")
     parser.add_argument("--play-from", help="Read the media from a file and sent it."),
+    parser.add_argument("--bind", default="0.0.0.0")
     parser.add_argument(
         "--port", type=int, default=8080, help="Port for HTTP server (default: 8080)"
     )
     parser.add_argument("--verbose", "-v", action="count")
     args = parser.parse_args()
+
+    if args.bind:
+        try:
+            host, port = args.bind.split(":", 1)
+        except ValueError:
+            host = args.bind
+            port = args.port
+    else:
+        port = args.port
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
@@ -101,4 +111,4 @@ if __name__ == "__main__":
     app.router.add_get("/", index)
     app.router.add_get("/client.js", javascript)
     app.router.add_post("/offer", offer)
-    web.run_app(app, port=args.port, ssl_context=ssl_context)
+    web.run_app(app, host=host, port=port, ssl_context=ssl_context)

--- a/examples/webcam/webcam.py
+++ b/examples/webcam/webcam.py
@@ -81,22 +81,14 @@ if __name__ == "__main__":
     parser.add_argument("--cert-file", help="SSL certificate file (for HTTPS)")
     parser.add_argument("--key-file", help="SSL key file (for HTTPS)")
     parser.add_argument("--play-from", help="Read the media from a file and sent it."),
-    parser.add_argument("--bind", default="0.0.0.0")
+    parser.add_argument(
+        "--host", default="0.0.0.0", help="Host for HTTP server (default: 0.0.0.0)"
+    )
     parser.add_argument(
         "--port", type=int, default=8080, help="Port for HTTP server (default: 8080)"
     )
     parser.add_argument("--verbose", "-v", action="count")
     args = parser.parse_args()
-
-    if args.bind:
-        try:
-            host, port = args.bind.split(":", 1)
-        except ValueError:
-            host = args.bind
-            port = args.port
-    else:
-        host = "0.0.0.0"
-        port = args.port
 
     if args.verbose:
         logging.basicConfig(level=logging.DEBUG)
@@ -112,4 +104,4 @@ if __name__ == "__main__":
     app.router.add_get("/", index)
     app.router.add_get("/client.js", javascript)
     app.router.add_post("/offer", offer)
-    web.run_app(app, host=host, port=port, ssl_context=ssl_context)
+    web.run_app(app, host=args.host, port=args.port, ssl_context=ssl_context)

--- a/examples/webcam/webcam.py
+++ b/examples/webcam/webcam.py
@@ -95,6 +95,7 @@ if __name__ == "__main__":
             host = args.bind
             port = args.port
     else:
+        host = "0.0.0.0"
         port = args.port
 
     if args.verbose:


### PR DESCRIPTION
Allow a custom bind address in example scripts.

By default, the example scripts try to bind to `0.0.0.0` which triggers firewall prompts to allow on macOS.  This allows running the examples scripts on `127.0.0.1` by doing `--bind=127.0.0.1`.