### PR TITLE
Support srcc id/label value with a colon

### DIFF
--- a/src/aiortc/sdp.py
+++ b/src/aiortc/sdp.py
@@ -432,7 +432,7 @@ class SessionDescription:
                     elif attr == "ssrc":
                         ssrc_str, ssrc_desc = value.split(" ", 1)
                         ssrc = int(ssrc_str)
-                        ssrc_attr, ssrc_value = ssrc_desc.split(":")
+                        ssrc_attr, ssrc_value = ssrc_desc.split(":", 1)
 
                         try:
                             ssrc_info = next(


### PR DESCRIPTION
Hello! I was trying to stream the video feed from an iOS Swift app with GoogleWebRTC to a Python backend with aiortc, but got the following error with aiortc:

```
Traceback (most recent call last):
  ...
  File "./app/routers/rtc_server.py", line 174, in offer
    await pc.setRemoteDescription(offer)
  File "/usr/local/lib/python3.8/site-packages/aiortc/rtcpeerconnection.py", line 752, in setRemoteDescription
    description = sdp.SessionDescription.parse(sessionDescription.sdp)
  File "/usr/local/lib/python3.8/site-packages/aiortc/sdp.py", line 435, in parse
    ssrc_attr, ssrc_value = ssrc_desc.split(":")
ValueError: too many values to unpack (expected 2)
```

After inspecting the local SDP from the Swift client that is sent to aiortc, I saw this at the bottom:
```
a=ssrc-group:FID 4290189036 2679013598
a=ssrc:4290189036 cname:wMEskGvvI7w1GwlN
a=ssrc:4290189036 msid:- com.apple.avfoundation.avcapturedevice.built-in_video:5
a=ssrc:4290189036 mslabel:-
a=ssrc:4290189036 label:com.apple.avfoundation.avcapturedevice.built-in_video:5
a=ssrc:2679013598 cname:wMEskGvvI7w1GwlN
a=ssrc:2679013598 msid:- com.apple.avfoundation.avcapturedevice.built-in_video:5
a=ssrc:2679013598 mslabel:-
a=ssrc:2679013598 label:com.apple.avfoundation.avcapturedevice.built-in_video:5
```
Apparently GoogleWebRTC uses the ID of the camera for the ssrc id and label which contains the `:5` at the end. The extra colon causes an error in aiortc when parsing the SDP.

This simple fix prevents the above error. Thanks for this helpful library!