### PR TITLE
Close source track even WebRTC signaling fails

### DIFF
--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -195,6 +195,12 @@ class RTCRtpSender:
             self.__rtp_task.cancel()
             self.__rtcp_task.cancel()
             await asyncio.gather(self.__rtp_exited.wait(), self.__rtcp_exited.wait())
+        self._stop_track()
+
+    def _stop_track(self):
+        if self.__track:
+            self.__track.stop()
+            self.__track = None
 
     async def _handle_rtcp_packet(self, packet):
         if isinstance(packet, (RtcpRrPacket, RtcpSrPacket)):
@@ -331,10 +337,7 @@ class RTCRtpSender:
             # so issue a warning if we hit an unexpected exception
             self.__log_warning(traceback.format_exc())
 
-        # stop track
-        if self.__track:
-            self.__track.stop()
-            self.__track = None
+        self._stop_track()
 
         self.__log_debug("- RTP finished")
         self.__rtp_exited.set()

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -197,7 +197,7 @@ class RTCRtpSender:
             await asyncio.gather(self.__rtp_exited.wait(), self.__rtcp_exited.wait())
         self._stop_track()
 
-    def _stop_track(self):
+    def _stop_track(self) -> None:
         if self.__track:
             self.__track.stop()
             self.__track = None

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -506,7 +506,7 @@ class RTCPeerConnectionTest(TestCase):
         run(transceiver.stop())
         self.assertEqual(transceiver.currentDirection, None)
         self.assertEqual(transceiver.direction, "sendonly")
-        self.assertEqual(transceiver.sender.track, track)
+        self.assertEqual(transceiver.sender.track, None)
         self.assertEqual(transceiver.stopped, True)
 
     def test_addTransceiver_audio_sendrecv(self):


### PR DESCRIPTION
Fix to issue #330. Now if v4l2 device if opened with `MediaPlayer` class, it will get properly closed when `RTCPeerConnection.close()` is called even if signaling fails. Previously track was only closed properly when signaling succeeded and sender worker was running.