### PR TITLE
Fix disappearing start/stop button in examples/server

### DIFF
--- a/examples/server/client.js
+++ b/examples/server/client.js
@@ -207,6 +207,8 @@ function stop() {
     setTimeout(function() {
         pc.close();
     }, 500);
+
+    document.getElementById('start').style.display = 'inline-block';
 }
 
 function sdpFilterCodec(kind, codec, realSdp) {


### PR DESCRIPTION
One line change, just made it so that the `Start` button on the html page reappears when clicking `Stop`. This allows for setting up a new RTCPeerConnection without refreshing the entire page.