### PR TITLE
Update README.rst

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -116,7 +116,7 @@ built from you will also need to run:
 
 .. code:: bash
 
-    apt install libsrtp2-dev
+    apt install libsrtp2-dev python3-dev
 
 OS X
 ....


### PR DESCRIPTION
Add "python3-dev" to things needed to install on Linux if your platform doesn't have a binary wheel available (e.g. a RaspberryPi)