### PR TITLE
fix Invalid element type (room should be a string)

### DIFF
--- a/examples/janus/janus.py
+++ b/examples/janus/janus.py
@@ -246,7 +246,7 @@ if __name__ == "__main__":
     loop = asyncio.get_event_loop()
     try:
         loop.run_until_complete(
-            run(player=player, recorder=recorder, room=args.room, session=session)
+            run(player=player, recorder=recorder, room=str(args.room), session=session)
         )
     except KeyboardInterrupt:
         pass


### PR DESCRIPTION
This fixes a minor bug in the Janus example. The default room (1234) is not a string, which causes an error response from Janus. This PR casts args.room to a string to fix this issue.

![image](https://user-images.githubusercontent.com/22998430/104089469-31a30680-5224-11eb-8f11-8568b119f759.png)
