### PR TITLE
[ice] defer and parallelise adding remote candidates

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -3,6 +3,12 @@ Changelog
 
 .. currentmodule:: aiortc
 
+1.1.1
+-----
+
+ * Defer adding remote candidates until after transport bundling to avoid
+   unnecessary mDNS lookups.
+
 1.1.0
 -----
 


### PR DESCRIPTION
Now that we support mDNS candidates, adding remote candidates can take some
time due to mDNS lookups. As we prune some transports due to bundling,
defer adding remote candidates until after pruning has taken place. We can
also add the candidates in parallel for the different transports.