### PR TITLE
Jitterbuffer fix + basic send PLI implementation

### DIFF
--- a/src/aiortc/jitterbuffer.py
+++ b/src/aiortc/jitterbuffer.py
@@ -27,7 +27,6 @@ class JitterBuffer:
         return self._capacity
 
     def add(self, packet: RtpPacket) -> Optional[JitterFrame]:
-        # print("[INFO][JitterBuffer] Received Seq:", packet.sequence_number)
         if self._origin is None:
             self._origin = packet.sequence_number
             delta = 0
@@ -38,8 +37,6 @@ class JitterBuffer:
 
         if misorder < delta:
             if misorder >= MAX_MISORDER:
-                # print("[INFO][JitterBuffer] Received Seq1:", packet.sequence_number, " Origin:", self._origin,
-                #       ' misorder:', self.__max_number)
                 self.smart_remove(self.capacity, dumb_mode=True)
                 self._origin = packet.sequence_number
                 delta = misorder = 0
@@ -48,13 +45,9 @@ class JitterBuffer:
             else:
                 return None
 
-        # print("[INFO][JitterBuffer] Received Seq2:", packet.sequence_number, " Origin:", self._origin,
-        #       ' delta:', delta)
-
         if delta >= self.capacity:
             # remove just enough frames to fit the received packets
             excess = delta - self.capacity + 1
-            print("[WARNING][JitterBuffer] At least:", excess, "packets will be lost")
             if self.smart_remove(excess):
                 self._origin = packet.sequence_number
             if self.sendPLI is not None:
@@ -90,8 +83,7 @@ class JitterBuffer:
                 # check we have prefetched enough
                 frames += 1
                 if frames >= self._prefetch:
-                    self.remove(remove)
-                    # self.smart_remove(remove, dumb_mode=True) # "remove" might still be a bit faster
+                    self.remove(remove)  # this might be a bit faster than smart_remove
                     return frame
 
                 # start a new frame
@@ -126,6 +118,5 @@ class JitterBuffer:
             self._packets[pos] = None
             self._origin = (self._origin + 1) % self.__max_number
             if i == self._capacity - 1:
-                print("[Warning][JitterBuffer] JitterBuffer purged !!!")
                 return True
         return False

--- a/src/aiortc/jitterbuffer.py
+++ b/src/aiortc/jitterbuffer.py
@@ -19,7 +19,6 @@ class JitterBuffer:
         self._origin: Optional[int] = None
         self._packets: List[Optional[RtpPacket]] = [None for i in range(capacity)]
         self._prefetch = prefetch
-        self.__max_number = 65536
 
     @property
     def capacity(self) -> int:
@@ -99,7 +98,7 @@ class JitterBuffer:
         for i in range(count):
             pos = self._origin % self._capacity
             self._packets[pos] = None
-            self._origin = (self._origin + 1) % self.__max_number
+            self._origin = uint16_add(self._origin, 1)
 
     def smart_remove(self, count: int) -> bool:
         """
@@ -115,7 +114,7 @@ class JitterBuffer:
                     break
                 timestamp = packet.timestamp
             self._packets[pos] = None
-            self._origin = (self._origin + 1) % self.__max_number
+            self._origin = uint16_add(self._origin, 1)
             if i == self._capacity - 1:
                 return True
         return False

--- a/src/aiortc/jitterbuffer.py
+++ b/src/aiortc/jitterbuffer.py
@@ -40,8 +40,7 @@ class JitterBuffer:
             if misorder >= MAX_MISORDER:
                 # print("[INFO][JitterBuffer] Received Seq1:", packet.sequence_number, " Origin:", self._origin,
                 #       ' misorder:', self.__max_number)
-                self.remove(self.capacity)
-                # self.smart_remove(self.capacity, dumb_mode=True) # "remove" might still be a bit faster
+                self.smart_remove(self.capacity, dumb_mode=True)
                 self._origin = packet.sequence_number
                 delta = misorder = 0
                 if self.sendPLI is not None:
@@ -128,5 +127,5 @@ class JitterBuffer:
             self._origin = (self._origin + 1) % self.__max_number
             if i == self._capacity - 1:
                 print("[Warning][JitterBuffer] JitterBuffer purged !!!")
-                return 1 
-        return 0
+                return True
+        return False

--- a/src/aiortc/jitterbuffer.py
+++ b/src/aiortc/jitterbuffer.py
@@ -13,12 +13,15 @@ class JitterFrame:
 
 
 class JitterBuffer:
-    def __init__(self, capacity: int, prefetch: int = 0) -> None:
+    def __init__(
+        self, capacity: int, prefetch: int = 0, is_video: bool = False
+    ) -> None:
         assert capacity & (capacity - 1) == 0, "capacity must be a power of 2"
         self._capacity = capacity
         self._origin: Optional[int] = None
         self._packets: List[Optional[RtpPacket]] = [None for i in range(capacity)]
         self._prefetch = prefetch
+        self._is_video = is_video
 
     @property
     def capacity(self) -> int:
@@ -39,7 +42,7 @@ class JitterBuffer:
                 self.remove(self.capacity)
                 self._origin = packet.sequence_number
                 delta = misorder = 0
-                if self._capacity >= 128:
+                if self._is_video:
                     pli_flag = True
             else:
                 return pli_flag, None
@@ -49,7 +52,7 @@ class JitterBuffer:
             excess = delta - self.capacity + 1
             if self.smart_remove(excess):
                 self._origin = packet.sequence_number
-            if self._capacity >= 128:
+            if self._is_video:
                 pli_flag = True
 
         pos = packet.sequence_number % self._capacity

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -254,7 +254,9 @@ class RTCRtpReceiver:
             self.__nack_generator = None
             self.__remote_bitrate_estimator = None
         else:
-            self.__jitter_buffer = JitterBuffer(capacity=128, sendPLI=self._send_rtcp_pli)
+            self.__jitter_buffer = JitterBuffer(
+                capacity=128, sendPLI=self._send_rtcp_pli
+            )
             self.__nack_generator = NackGenerator()
             self.__remote_bitrate_estimator = RemoteBitrateEstimator()
         self._track: Optional[RemoteStreamTrack] = None

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -490,7 +490,7 @@ class RTCRtpReceiver:
         pli_flag, encoded_frame = self.__jitter_buffer.add(packet)
         # check if the PLI should be sent
         if pli_flag:
-            asyncio.ensure_future(self._send_rtcp_pli(packet.ssrc))
+            await self._send_rtcp_pli(packet.ssrc)
 
         # if we have a complete encoded frame, decode it
         if encoded_frame is not None and self.__decoder_thread:

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -254,7 +254,7 @@ class RTCRtpReceiver:
             self.__nack_generator = None
             self.__remote_bitrate_estimator = None
         else:
-            self.__jitter_buffer = JitterBuffer(capacity=128)
+            self.__jitter_buffer = JitterBuffer(capacity=128, sendPLI = self._send_rtcp_pli)
             self.__nack_generator = NackGenerator()
             self.__remote_bitrate_estimator = RemoteBitrateEstimator()
         self._track: Optional[RemoteStreamTrack] = None

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -254,7 +254,7 @@ class RTCRtpReceiver:
             self.__nack_generator = None
             self.__remote_bitrate_estimator = None
         else:
-            self.__jitter_buffer = JitterBuffer(capacity=128, sendPLI = self._send_rtcp_pli)
+            self.__jitter_buffer = JitterBuffer(capacity=128, sendPLI=self._send_rtcp_pli)
             self.__nack_generator = NackGenerator()
             self.__remote_bitrate_estimator = RemoteBitrateEstimator()
         self._track: Optional[RemoteStreamTrack] = None

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -254,9 +254,7 @@ class RTCRtpReceiver:
             self.__nack_generator = None
             self.__remote_bitrate_estimator = None
         else:
-            self.__jitter_buffer = JitterBuffer(
-                capacity=128, sendPLI=self._send_rtcp_pli
-            )
+            self.__jitter_buffer = JitterBuffer(capacity=128)
             self.__nack_generator = NackGenerator()
             self.__remote_bitrate_estimator = RemoteBitrateEstimator()
         self._track: Optional[RemoteStreamTrack] = None
@@ -489,7 +487,10 @@ class RTCRtpReceiver:
             return
 
         # try to re-assemble encoded frame
-        encoded_frame = self.__jitter_buffer.add(packet)
+        pli_flag, encoded_frame = self.__jitter_buffer.add(packet)
+        # check if the PLI should be sent
+        if pli_flag:
+            asyncio.ensure_future(self._send_rtcp_pli(packet.ssrc))
 
         # if we have a complete encoded frame, decode it
         if encoded_frame is not None and self.__decoder_thread:

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -254,7 +254,7 @@ class RTCRtpReceiver:
             self.__nack_generator = None
             self.__remote_bitrate_estimator = None
         else:
-            self.__jitter_buffer = JitterBuffer(capacity=128)
+            self.__jitter_buffer = JitterBuffer(capacity=128, is_video=True)
             self.__nack_generator = NackGenerator()
             self.__remote_bitrate_estimator = RemoteBitrateEstimator()
         self._track: Optional[RemoteStreamTrack] = None

--- a/tests/test_jitterbuffer.py
+++ b/tests/test_jitterbuffer.py
@@ -218,7 +218,7 @@ class JitterBufferTest(TestCase):
         self.assertEqual(jbuffer._origin, 2)
         self.assertPackets(jbuffer, [None, None, 2, 3])
 
-        # remove 2 packets
+        # remove 1 packet using dumb mode
         jbuffer.smart_remove(1, dumb_mode=True)
         self.assertEqual(jbuffer._origin, 3)
         self.assertPackets(jbuffer, [None, None, None, 3])

--- a/tests/test_jitterbuffer.py
+++ b/tests/test_jitterbuffer.py
@@ -259,7 +259,7 @@ class JitterBufferTest(TestCase):
         """
         Video jitter buffer.
         """
-        jbuffer = JitterBuffer(capacity=128)
+        jbuffer = JitterBuffer(capacity=128, is_video=True)
 
         packet = RtpPacket(sequence_number=0, timestamp=1234)
         packet._data = b"0000"
@@ -287,7 +287,7 @@ class JitterBufferTest(TestCase):
         """
         Video jitter buffer.
         """
-        jbuffer = JitterBuffer(capacity=128)
+        jbuffer = JitterBuffer(capacity=128, is_video=True)
 
         pli_flag, frame = jbuffer.add(RtpPacket(sequence_number=2000, timestamp=1234))
         self.assertIsNone(frame)


### PR DESCRIPTION
Hi,
I've prepared a fix that may interest a lot of people having picture lost issues. I discovered that a big part of those issues might be related with a bad implementation of a jitter buffer that is used for collecting RTP packets before they are passed to the appropriate decoding function. You see, each of the RTP packets sent by a browser (sender) has a packet number that is used to properly group the packets into video frames on the receiver side. In theory those packet numbers should be unique, in practice however they are limited by the unsigned short int size which is 65535. Unfortunately the aiortc jitter buffer implementation did not handle the packet numbering return from 65535 to 0 correctly, causing the jitter buffer to be purged and the video signal to be lost or at least largely degraded. The situation repeated itself every 65535 received packets and was complicated by the fact that the aiortc does not support sending PLI (picture lost indicator) messages. Without the PLI messages being sent that video image could remain corrupted indefinitely as it is the video encoder decision if and when to send a new keyframe (in webRTC this usually happens on a rapid scene change or when it is explicitly requested through PLI).

This commit fixes the jitter buffer issue and adds a simple send PLI mechanism to the jitter buffer implementation.