### PR TITLE
[Develop] Settings option for dev in setup and update  gitignore

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -46,8 +46,7 @@ jobs:
       - name: Run tests
         run: |
           python -m pip install -U pip setuptools wheel
-          pip install aiohttp coverage numpy websockets
-          pip install .
+          pip install .[dev]
           coverage run -m unittest discover -v
           coverage xml
         shell: bash

--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,12 @@
 /build
 /dist
 /docs/_build
+
+# Environments
+.env
+.venv
+env/
+venv/
+ENV/
+env.bak/
+venv.bak/

--- a/setup.py
+++ b/setup.py
@@ -28,6 +28,15 @@ install_requires = [
     "pylibsrtp>=0.5.6",
 ]
 
+extras_require = {
+    'dev': [
+        'aiohttp>=3.7.0',
+        'coverage>=5.0',
+        'numpy>=1.19.0',
+        'websockets>=8.0',
+    ]
+}
+
 if os.environ.get("READTHEDOCS") == "True":
     cffi_modules = []
     install_requires = list(filter(lambda x: not x.startswith("av"), install_requires))
@@ -59,4 +68,5 @@ setuptools.setup(
     packages=["aiortc", "aiortc.codecs", "aiortc.contrib"],
     setup_requires=["cffi>=1.0.0"],
     install_requires=install_requires,
+    extras_require=extras_require,
 )


### PR DESCRIPTION
When installing editable option, enables option to install aiohttp and websockets to be able to run all tests local.

Update gitignore to exclude venvs