### PR TITLE
[dtls] correctly route RTP packets for overlapping payload types

### DIFF
--- a/src/aiortc/rtcdtlstransport.py
+++ b/src/aiortc/rtcdtlstransport.py
@@ -249,7 +249,7 @@ class RtpRouter:
         self.senders: Dict[int, Any] = {}
         self.mid_table: Dict[str, Any] = {}
         self.ssrc_table: Dict[int, Any] = {}
-        self.payload_type_table: Dict[int, Any] = {}
+        self.payload_type_table: Dict[int, Set] = {}
 
     def register_receiver(
         self,
@@ -264,7 +264,9 @@ class RtpRouter:
         for ssrc in ssrcs:
             self.ssrc_table[ssrc] = receiver
         for payload_type in payload_types:
-            self.payload_type_table[payload_type] = receiver
+            if payload_type not in self.payload_type_table:
+                self.payload_type_table[payload_type] = set()
+            self.payload_type_table[payload_type].add(receiver)
 
     def register_sender(self, sender, ssrc: int) -> None:
         self.senders[ssrc] = sender
@@ -302,14 +304,15 @@ class RtpRouter:
 
     def route_rtp(self, packet: RtpPacket) -> Optional[Any]:
         ssrc_receiver = self.ssrc_table.get(packet.ssrc)
-        pt_receiver = self.payload_type_table.get(packet.payload_type)
+        pt_receivers = self.payload_type_table.get(packet.payload_type, set())
 
         # the SSRC and payload type are known and match
-        if ssrc_receiver is not None and ssrc_receiver == pt_receiver:
+        if ssrc_receiver is not None and ssrc_receiver in pt_receivers:
             return ssrc_receiver
 
         # the SSRC is unknown but the payload type matches, update the SSRC table
-        if ssrc_receiver is None and pt_receiver is not None:
+        if ssrc_receiver is None and len(pt_receivers) == 1:
+            pt_receiver = list(pt_receivers)[0]
             self.ssrc_table[packet.ssrc] = pt_receiver
             return pt_receiver
 
@@ -320,7 +323,8 @@ class RtpRouter:
         self.receivers.discard(receiver)
         self.__discard(self.mid_table, receiver)
         self.__discard(self.ssrc_table, receiver)
-        self.__discard(self.payload_type_table, receiver)
+        for pt, receivers in self.payload_type_table.items():
+            receivers.discard(receiver)
 
     def unregister_sender(self, sender) -> None:
         self.__discard(self.senders, sender)

--- a/tests/test_rtcdtlstransport.py
+++ b/tests/test_rtcdtlstransport.py
@@ -555,3 +555,29 @@ class RtpRouterTest(TestCase):
 
         # unknown SSRC and payload type
         self.assertEqual(router.route_rtp(RtpPacket(ssrc=6789, payload_type=100)), None)
+
+    def test_route_rtp_ambiguous_payload_type(self):
+        receiver1 = object()
+        receiver2 = object()
+
+        router = RtpRouter()
+        router.register_receiver(receiver1, ssrcs=[1234, 2345], payload_types=[96, 97])
+        router.register_receiver(receiver2, ssrcs=[3456, 4567], payload_types=[96, 97])
+
+        # known SSRC and payload type
+        self.assertEqual(
+            router.route_rtp(RtpPacket(ssrc=1234, payload_type=96)), receiver1
+        )
+        self.assertEqual(
+            router.route_rtp(RtpPacket(ssrc=2345, payload_type=97)), receiver1
+        )
+        self.assertEqual(
+            router.route_rtp(RtpPacket(ssrc=3456, payload_type=96)), receiver2
+        )
+        self.assertEqual(
+            router.route_rtp(RtpPacket(ssrc=4567, payload_type=97)), receiver2
+        )
+
+        # unknown SSRC, ambiguous payload type
+        self.assertEqual(router.route_rtp(RtpPacket(ssrc=5678, payload_type=96)), None)
+        self.assertEqual(router.route_rtp(RtpPacket(ssrc=5678, payload_type=97)), None)


### PR DESCRIPTION
Correctly route RTP packets when several media sections use the same
payload types.

Fixes: #382