### PR TITLE
[logging] disable PyAV logging infrastructure

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,7 +38,12 @@ class MockBinding:
     lib = MockLib()
 
 
+class MockAvLogging:
+    restore_default_callback = lambda x: None
+
+
 class MockAv:
+    logging = MockAvLogging()
     AudioFrame = None
     VideoFrame = None
 
@@ -66,6 +71,7 @@ class MockVpx:
 
 sys.modules.update({'av': MockAv()})
 sys.modules.update({'av.frame': MockAvFrame()})
+sys.modules.update({'av.logging': MockAvLogging()})
 sys.modules.update({'pylibsrtp._binding': MockBinding()})
 sys.modules.update({'aiortc.codecs.h264': MockH264()})
 sys.modules.update({'aiortc.codecs.opus': MockOpus()})

--- a/src/aiortc/__init__.py
+++ b/src/aiortc/__init__.py
@@ -1,6 +1,8 @@
 # flake8: noqa
 import logging
 
+import av.logging
+
 from .about import __version__
 from .exceptions import InvalidAccessError, InvalidStateError
 from .mediastreams import MediaStreamTrack, VideoStreamTrack
@@ -45,6 +47,9 @@ from .stats import (
     RTCStatsReport,
     RTCTransportStats,
 )
+
+# Disable PyAV's logging framework as it can lead to thread deadlocks.
+av.logging.restore_default_callback()
 
 # Set default logging handler to avoid "No handler found" warnings.
 logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
It can lead to threading deadlocks, for instance avcodec_open2() hangs
with the h264_omx encoder.