### PR TITLE
[h264] use hardware-accelerated h264_omx when available

### DIFF
--- a/stubs/av/__init__.pyi
+++ b/stubs/av/__init__.pyi
@@ -6,6 +6,8 @@ from .frame import Frame
 class AVError(Exception): ...
 
 class CodecContext:
+    bit_rate: int
+    framerate: Fraction
     height: int
     options: Dict[str, str]
     pix_fmt: str
@@ -15,6 +17,7 @@ class CodecContext:
     def create(codec: str, mode: Optional[str] = ...) -> CodecContext: ...
     def decode(self, packet: Packet) -> List[Frame]: ...
     def encode(self, frame: Frame) -> List[Packet]: ...
+    def open(self) -> None: ...
 
 class Packet:
     pts: int


### PR DESCRIPTION
On devices such as Raspberry Pi 4 we can leverage the
hardware-accelerated h264_omx encoder. Use it when possible.