### PR TITLE
Add stop function to MediaPlayer

### DIFF
--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -302,6 +302,16 @@ class MediaPlayer:
         if not self.__started and self.__container is not None:
             self.__container.close()
             self.__container = None
+            
+    def stop(self):
+        """
+        Stop playing all tracks
+        """
+        if not self.__started:
+            self._stop(None)
+        else:
+            for track in self.__started:
+                self._stop(track)
 
     def __log_debug(self, msg: str, *args) -> None:
         logger.debug(f"MediaPlayer(%s) {msg}", self.__container.name, *args)


### PR DESCRIPTION
As of right now it is not possible to stop the MediaPlayer without having added it to a RTCPeerConnection. In case of the `webcam` example this means the application will not fully close if no-one connected

This PR adds a simple stop function that first tries to close all started tracks and else just calls the _close function without a track, so that it closes the av container + thread

Fixes #500 