### PR TITLE
[peer connection] make use of remote candidates with sdpMLineIndex only

### DIFF
--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -385,7 +385,8 @@ class RTCPeerConnection(AsyncIOEventEmitter):
             raise ValueError("Candidate must have either sdpMid or sdpMLineIndex")
 
         for transceiver in self.__transceivers:
-            if candidate.sdpMid == transceiver.mid and not transceiver._bundled:
+            if candidate.sdpMLineIndex == transceiver.mline_index or \
+                    (candidate.sdpMid == transceiver.mid and not transceiver._bundled):
                 iceTransport = transceiver._transport.transport
                 await iceTransport.addRemoteCandidate(candidate)
                 return
@@ -1059,7 +1060,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
 
     def __getTransceiverByMLineIndex(self, index: int) -> Optional[RTCRtpTransceiver]:
         return next(
-            filter(lambda x: x._get_mline_index() == index, self.__transceivers), None
+            filter(lambda x: x.mline_index == index, self.__transceivers), None
         )
 
     def __localDescription(self) -> Optional[sdp.SessionDescription]:
@@ -1083,7 +1084,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         return self.__pendingRemoteDescription or self.__currentRemoteDescription
 
     def __remoteRtp(self, transceiver: RTCRtpTransceiver) -> RTCRtpReceiveParameters:
-        media = self.__remoteDescription().media[transceiver._get_mline_index()]
+        media = self.__remoteDescription().media[transceiver.mline_index]
 
         receiveParameters = RTCRtpReceiveParameters(
             codecs=transceiver._codecs,

--- a/src/aiortc/rtcrtptransceiver.py
+++ b/src/aiortc/rtcrtptransceiver.py
@@ -80,6 +80,10 @@ class RTCRtpTransceiver:
         return self.__mid
 
     @property
+    def mline_index(self) -> Optional[int]:
+        return self.__mline_index
+
+    @property
     def receiver(self) -> RTCRtpReceiver:
         """
         The :class:`RTCRtpReceiver` that handles receiving and decoding
@@ -131,9 +135,6 @@ class RTCRtpTransceiver:
 
     def _set_mid(self, mid: str) -> None:
         self.__mid = mid
-
-    def _get_mline_index(self) -> Optional[int]:
-        return self.__mline_index
 
     def _set_mline_index(self, idx: int) -> None:
         self.__mline_index = idx


### PR DESCRIPTION
## Motivation

`aiortc`'s `RTCPeerConnection` drops a remote candidate with `sdpMLineIndex` only. This is problematic if 
- the remote peer is under `ICE` lite implementation, and
- it generates a candidate with `sdpMLineIndex` only.

In this case, no agent sends out `STUN` binding request to each other, which necessarily leads to connectivity check timeout. This is an effort to make `aiortc` compatible with [`Pion`](https://github.com/pion/webrtc).