### PR TITLE
feat: creating media player that works without transcoding

### DIFF
--- a/src/aiortc/codecs/base.py
+++ b/src/aiortc/codecs/base.py
@@ -2,6 +2,7 @@ from abc import ABCMeta, abstractmethod
 from typing import List, Tuple
 
 from av.frame import Frame
+from av.packet import Packet
 
 from ..jitterbuffer import JitterFrame
 
@@ -18,3 +19,6 @@ class Encoder(metaclass=ABCMeta):
         self, frame: Frame, force_keyframe: bool = False
     ) -> Tuple[List[bytes], int]:
         pass  # pragma: no cover
+
+    def pack(self, packet: Packet) -> Tuple[List[bytes], int]:
+        return bytes(packet), int(packet.pts)

--- a/src/aiortc/codecs/h264.py
+++ b/src/aiortc/codecs/h264.py
@@ -7,6 +7,7 @@ from typing import Iterator, List, Optional, Sequence, Tuple, Type, TypeVar
 
 import av
 from av.frame import Frame
+from av.packet import Packet
 
 from ..jitterbuffer import JitterFrame
 from ..mediastreams import VIDEO_TIME_BASE, convert_timebase
@@ -318,6 +319,11 @@ class H264Encoder(Encoder):
         packages = self._encode_frame(frame, force_keyframe)
         timestamp = convert_timebase(frame.pts, frame.time_base, VIDEO_TIME_BASE)
         return self._packetize(packages), timestamp
+
+    def pack(self, packet: Packet) -> Tuple[List[bytes], int]:
+        assert isinstance(packet, av.Packet)
+        packages = self._split_bitstream(bytes(packet))
+        return self._packetize(packages), int(packet.pts)
 
     @property
     def target_bitrate(self) -> int:

--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -4,16 +4,17 @@ import fractions
 import logging
 import threading
 import time
-from typing import Dict, Optional, Set
+from typing import Dict, Optional, Set, Union
 
 import av
 from av import AudioFrame, VideoFrame
 from av.frame import Frame
+from av.packet import Packet
+from av.video.stream import VideoStream
 
 from ..mediastreams import AUDIO_PTIME, MediaStreamError, MediaStreamTrack
 
 logger = logging.getLogger(__name__)
-
 
 REAL_TIME_FORMATS = [
     "alsa",
@@ -81,7 +82,7 @@ class MediaBlackhole:
         self.__tracks = {}
 
 
-def player_worker(
+def player_worker_decode(
     loop,
     container,
     streams,
@@ -109,7 +110,7 @@ def player_worker(
     while not quit_event.is_set():
         try:
             frame = next(container.decode(*streams))
-        except (av.AVError, StopIteration) as exc:
+        except Exception as exc:
             if isinstance(exc, av.FFmpegError) and exc.errno == errno.EAGAIN:
                 time.sleep(0.01)
                 continue
@@ -153,6 +154,47 @@ def player_worker(
             asyncio.run_coroutine_threadsafe(video_track._queue.put(frame), loop)
 
 
+def player_worker_demux(
+    loop,
+    container,
+    streams,
+    audio_track,
+    video_track,
+    quit_event,
+    throttle_playback,
+    loop_playback,
+):
+    frame_time = None
+    start_time = time.time()
+
+    while not quit_event.is_set():
+        try:
+            packet = next(container.demux(*streams))
+            if not packet.size:
+                raise StopIteration
+        except Exception as exc:
+            if isinstance(exc, av.FFmpegError) and exc.errno == errno.EAGAIN:
+                time.sleep(0.01)
+                continue
+            if isinstance(exc, StopIteration) and loop_playback:
+                container.seek(0)
+                continue
+            if video_track:
+                asyncio.run_coroutine_threadsafe(video_track._queue.put(None), loop)
+            break
+
+        # read up to 1 second ahead
+        if throttle_playback:
+            elapsed_time = time.time() - start_time
+            if frame_time and frame_time > elapsed_time + 1:
+                time.sleep(0.1)
+
+        if isinstance(packet.stream, VideoStream) and video_track:
+            if packet.pts is not None and packet.time_base is not None:
+                frame_time = int(packet.pts * packet.time_base)
+                asyncio.run_coroutine_threadsafe(video_track._queue.put(packet), loop)
+
+
 class PlayerStreamTrack(MediaStreamTrack):
     def __init__(self, player, kind):
         super().__init__()
@@ -161,30 +203,33 @@ class PlayerStreamTrack(MediaStreamTrack):
         self._queue = asyncio.Queue()
         self._start = None
 
-    async def recv(self):
+    async def recv(self) -> Union[Frame, Packet]:
         if self.readyState != "live":
             raise MediaStreamError
 
         self._player._start(self)
-        frame = await self._queue.get()
-        if frame is None:
+        data = await self._queue.get()
+        if data is None:
             self.stop()
             raise MediaStreamError
-        frame_time = frame.time
+        if isinstance(data, Frame):
+            data_time = data.time
+        elif isinstance(data, Packet):
+            data_time = float(data.pts * data.time_base)
 
         # control playback rate
         if (
             self._player is not None
             and self._player._throttle_playback
-            and frame_time is not None
+            and data_time is not None
         ):
             if self._start is None:
-                self._start = time.time() - frame_time
+                self._start = time.time() - data_time
             else:
-                wait = self._start + frame_time - time.time()
+                wait = self._start + data_time - time.time()
                 await asyncio.sleep(wait)
 
-        return frame
+        return data
 
     def stop(self):
         super().stop()
@@ -230,7 +275,7 @@ class MediaPlayer:
     :param loop: Whether to repeat playback indefinitely (requires a seekable file).
     """
 
-    def __init__(self, file, format=None, options={}, loop=False):
+    def __init__(self, file, format=None, options={}, loop=False, decode=True):
         self.__container = av.open(file=file, format=format, mode="r", options=options)
         self.__thread: Optional[threading.Thread] = None
         self.__thread_quit: Optional[threading.Event] = None
@@ -238,15 +283,22 @@ class MediaPlayer:
         # examine streams
         self.__started: Set[PlayerStreamTrack] = set()
         self.__streams = []
+        self.__decode = decode
         self.__audio: Optional[PlayerStreamTrack] = None
         self.__video: Optional[PlayerStreamTrack] = None
         for stream in self.__container.streams:
             if stream.type == "audio" and not self.__audio:
-                self.__audio = PlayerStreamTrack(self, kind="audio")
-                self.__streams.append(stream)
+                if self.__decode:
+                    self.__audio = PlayerStreamTrack(self, kind="audio")
+                    self.__streams.append(stream)
             elif stream.type == "video" and not self.__video:
-                self.__video = PlayerStreamTrack(self, kind="video")
-                self.__streams.append(stream)
+                if not self.__decode:
+                    if stream.codec_context.name in ["h264", "mpeg4"]:
+                        self.__video = PlayerStreamTrack(self, kind="video")
+                        self.__streams.append(stream)
+                else:
+                    self.__video = PlayerStreamTrack(self, kind="video")
+                    self.__streams.append(stream)
 
         # check whether we need to throttle playback
         container_format = set(self.__container.format.name.split(","))
@@ -279,7 +331,7 @@ class MediaPlayer:
             self.__thread_quit = threading.Event()
             self.__thread = threading.Thread(
                 name="media-player",
-                target=player_worker,
+                target=player_worker_decode if self.__decode else player_worker_demux,
                 args=(
                     asyncio.get_event_loop(),
                     self.__container,

--- a/src/aiortc/mediastreams.py
+++ b/src/aiortc/mediastreams.py
@@ -3,10 +3,11 @@ import fractions
 import time
 import uuid
 from abc import ABCMeta, abstractmethod
-from typing import Tuple
+from typing import Tuple, Union
 
 from av import AudioFrame, VideoFrame
 from av.frame import Frame
+from av.packet import Packet
 from pyee.asyncio import AsyncIOEventEmitter
 
 AUDIO_PTIME = 0.020  # 20ms audio packetization
@@ -51,9 +52,10 @@ class MediaStreamTrack(AsyncIOEventEmitter, metaclass=ABCMeta):
         return "ended" if self.__ended else "live"
 
     @abstractmethod
-    async def recv(self) -> Frame:
+    async def recv(self) -> Union[Frame, Packet]:
         """
-        Receive the next :class:`~av.audio.frame.AudioFrame` or :class:`~av.video.frame.VideoFrame`.
+        Receive the next :class:`~av.audio.frame.AudioFrame`, :class:`~av.video.frame.VideoFrame`
+        or :class:`~av.packet.Packet`
         """
 
     def stop(self) -> None:

--- a/tests/codecs.py
+++ b/tests/codecs.py
@@ -2,6 +2,7 @@ import fractions
 from unittest import TestCase
 
 from av import AudioFrame, VideoFrame
+from av.packet import Packet
 
 from aiortc.codecs import depayload, get_decoder, get_encoder
 from aiortc.jitterbuffer import JitterFrame
@@ -46,6 +47,16 @@ class CodecTestCase(TestCase):
         frame.pts = pts
         frame.time_base = time_base
         return frame
+
+    def create_video_packet(self, header, pts):
+        """
+        Create a single blank video packet.
+        """
+        buffer = header + [0]
+        packet = Packet(len(buffer))
+        packet.update(bytes(buffer))
+        packet.pts = pts
+        return packet
 
     def create_video_frames(self, width, height, count, time_base=VIDEO_TIME_BASE):
         """

--- a/tests/test_g711.py
+++ b/tests/test_g711.py
@@ -60,6 +60,14 @@ class PcmaTest(CodecTestCase):
             self.assertEqual(payloads, [b"\xd5" * 160])
             self.assertEqual(timestamp, frame.pts // 6)
 
+    def test_packer(self):
+        encoder = get_encoder(PCMA_CODEC)
+        self.assertTrue(isinstance(encoder, PcmaEncoder))
+
+        packet = self.create_video_packet(header=[0], pts=0)
+        packages, timestamp = encoder.pack(packet)
+        self.assertGreaterEqual(len(packages), 1)
+
     def test_roundtrip(self):
         self.roundtrip_audio(PCMA_CODEC, output_layout="mono", output_sample_rate=8000)
 

--- a/tests/test_h264.py
+++ b/tests/test_h264.py
@@ -116,6 +116,14 @@ class H264Test(CodecTestCase):
         packages, timestamp = encoder.encode(frame)
         self.assertGreaterEqual(len(packages), 1)
 
+    def test_packer(self):
+        encoder = get_encoder(H264_CODEC)
+        self.assertTrue(isinstance(encoder, H264Encoder))
+
+        packet = self.create_video_packet(header=[0, 0, 1], pts=0)
+        packages, timestamp = encoder.pack(packet)
+        self.assertGreaterEqual(len(packages), 1)
+
     def test_encoder_buffering(self):
         create_encoder_context = h264.create_encoder_context
 

--- a/tests/test_mediastreams.py
+++ b/tests/test_mediastreams.py
@@ -1,6 +1,55 @@
+import asyncio
+import fractions
+import time
+from typing import Tuple
 from unittest import TestCase
 
-from aiortc.mediastreams import AudioStreamTrack, VideoStreamTrack
+from av.packet import Packet
+
+from aiortc.mediastreams import (
+    VIDEO_CLOCK_RATE,
+    VIDEO_PTIME,
+    VIDEO_TIME_BASE,
+    AudioStreamTrack,
+    MediaStreamTrack,
+    VideoStreamTrack,
+)
+
+
+class VideoPacketStreamTrack(MediaStreamTrack):
+    """
+    A dummy video native track which reads green frames.
+    """
+
+    kind = "video"
+
+    _start: float
+    _timestamp: int
+
+    async def next_timestamp(self) -> Tuple[int, fractions.Fraction]:
+        if hasattr(self, "_timestamp"):
+            self._timestamp += int(VIDEO_PTIME * VIDEO_CLOCK_RATE)
+            wait = self._start + (self._timestamp / VIDEO_CLOCK_RATE) - time.time()
+            await asyncio.sleep(wait)
+        else:
+            self._start = time.time()
+            self._timestamp = 0
+        return self._timestamp, VIDEO_TIME_BASE
+
+    async def recv(self) -> Packet:
+        """
+        Receive the next :class:`~av.packet.Packet`.
+
+        The base implementation dummy packet h264 for tests
+        """
+        pts, time_base = await self.next_timestamp()
+        header = [0, 0, 0, 1]
+        buffer = header + [0] * 1020
+        packet = Packet(len(buffer))
+        packet.update(bytes(buffer))
+        packet.pts = pts
+        packet.time_base = time_base
+        return packet
 
 
 class MediaStreamTrackTest(TestCase):
@@ -11,5 +60,10 @@ class MediaStreamTrackTest(TestCase):
 
     def test_video(self):
         track = VideoStreamTrack()
+        self.assertEqual(track.kind, "video")
+        self.assertEqual(len(track.id), 36)
+
+    def test_native_video(self):
+        track = VideoPacketStreamTrack()
         self.assertEqual(track.kind, "video")
         self.assertEqual(len(track.id), 36)

--- a/tests/test_opus.py
+++ b/tests/test_opus.py
@@ -72,6 +72,14 @@ class OpusTest(CodecTestCase):
         payloads, timestamp = encoder.encode(frames[1])
         self.assertEqual(timestamp, 960)
 
+    def test_packer(self):
+        encoder = get_encoder(OPUS_CODEC)
+        self.assertTrue(isinstance(encoder, OpusEncoder))
+
+        packet = self.create_video_packet(header=[0], pts=0)
+        packages, timestamp = encoder.pack(packet)
+        self.assertGreaterEqual(len(packages), 1)
+
     def test_roundtrip(self):
         self.roundtrip_audio(
             OPUS_CODEC, output_layout="stereo", output_sample_rate=48000

--- a/tests/test_vpx.py
+++ b/tests/test_vpx.py
@@ -194,6 +194,14 @@ class Vp8Test(CodecTestCase):
         self.assertTrue(len(payloads[0]) < 1300)
         self.assertEqual(timestamp, 0)
 
+    def test_packer(self):
+        encoder = get_encoder(VP8_CODEC)
+        self.assertTrue(isinstance(encoder, Vp8Encoder))
+
+        packet = self.create_video_packet(header=[0], pts=0)
+        packages, timestamp = encoder.pack(packet)
+        self.assertGreaterEqual(len(packages), 1)
+
     def test_encoder_large(self):
         encoder = get_encoder(VP8_CODEC)
         self.assertIsInstance(encoder, Vp8Encoder)


### PR DESCRIPTION
I've tested `janus` example. However, I noticed that always transcode process happens, even though input codec is the same of output. I checked cpu processing consumption with transcode is ~60%.

In this PR I add an option in example that transcode does not happens. With this, cpu processing reduce to ~3% and has the same visual result. Also, latency reduce ~1.5s for video in Full HD (`1920x1080`). In this implementation, `native media player` uses h264 codec.