### PR TITLE
Implemented ability to forward an encoded stream without re-encoding a…

### DIFF
--- a/examples/picamera/README.rst
+++ b/examples/picamera/README.rst
@@ -1,0 +1,28 @@
+Webcam server
+=============
+
+This example illustrates how to use a raspberry pi and picamera to send h264 encoded video (using hardware encoder) to the browser.
+
+Running
+-------
+
+First install the required packages:
+
+.. code-block:: console
+
+    $ pip install aiohttp aiortc picamera
+
+When you start the example, it will create an HTTP server which you
+can connect to from your browser:
+
+.. code-block:: console
+
+    $ python picam.py
+
+You can then browse to the following page with your browser:
+
+http://127.0.0.1:8080
+
+Once you click `Start` the server will send video from the raspberry pi camera to the
+browser.
+

--- a/examples/picamera/client.js
+++ b/examples/picamera/client.js
@@ -1,0 +1,73 @@
+var pc = null;
+
+function negotiate() {
+    pc.addTransceiver('video', {direction: 'recvonly'});
+    return pc.createOffer().then(function(offer) {
+        return pc.setLocalDescription(offer);
+    }).then(function() {
+        // wait for ICE gathering to complete
+        return new Promise(function(resolve) {
+            if (pc.iceGatheringState === 'complete') {
+                resolve();
+            } else {
+                function checkState() {
+                    if (pc.iceGatheringState === 'complete') {
+                        pc.removeEventListener('icegatheringstatechange', checkState);
+                        resolve();
+                    }
+                }
+                pc.addEventListener('icegatheringstatechange', checkState);
+            }
+        });
+    }).then(function() {
+        var offer = pc.localDescription;
+        return fetch('/offer', {
+            body: JSON.stringify({
+                sdp: offer.sdp,
+                type: offer.type,
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            method: 'POST'
+        });
+    }).then(function(response) {
+        return response.json();
+    }).then(function(answer) {
+        return pc.setRemoteDescription(answer);
+    }).catch(function(e) {
+        alert(e);
+    });
+}
+
+function start() {
+    var config = {
+        sdpSemantics: 'unified-plan'
+    };
+
+    if (document.getElementById('use-stun').checked) {
+        config.iceServers = [{urls: ['stun:stun.l.google.com:19302']}];
+    }
+
+    pc = new RTCPeerConnection(config);
+
+    // connect video
+    pc.addEventListener('track', function(evt) {
+        if (evt.track.kind == 'video') {
+            document.getElementById('video').srcObject = evt.streams[0];
+        }
+    });
+
+    document.getElementById('start').style.display = 'none';
+    negotiate();
+    document.getElementById('stop').style.display = 'inline-block';
+}
+
+function stop() {
+    document.getElementById('stop').style.display = 'none';
+
+    // close peer connection
+    setTimeout(function() {
+        pc.close();
+    }, 500);
+}

--- a/examples/picamera/index.html
+++ b/examples/picamera/index.html
@@ -1,0 +1,40 @@
+<html>
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebRTC Pi Camera</title>
+    <style>
+    button {
+        padding: 8px 16px;
+    }
+
+    video {
+        width: 100%;
+    }
+
+    .option {
+        margin-bottom: 8px;
+    }
+
+    #media {
+        max-width: 1280px;
+    }
+    </style>
+</head>
+<body>
+
+<div class="option">
+    <input id="use-stun" type="checkbox"/>
+    <label for="use-stun">Use STUN server</label>
+</div>
+<button id="start" onclick="start()">Start</button>
+<button id="stop" style="display: none" onclick="stop()">Stop</button>
+
+<div id="media">
+    <h2>Media</h2>
+    <video id="video" autoplay="true" playsinline="true"></video>
+</div>
+
+<script src="client.js"></script>
+</body>
+</html>

--- a/examples/picamera/picam.py
+++ b/examples/picamera/picam.py
@@ -1,0 +1,103 @@
+import asyncio
+import json
+import os
+
+import picamera
+from aiohttp import web
+from pitrack import PiH264StreamTrack
+
+from aiortc import RTCPeerConnection, RTCRtpSender, RTCSessionDescription
+
+ROOT = os.path.dirname(__file__)
+camera = None
+
+
+def create_pi_track():
+    global camera
+    video_track = PiH264StreamTrack(30)
+    camera = picamera.PiCamera()
+    camera.resolution = (1280, 720)
+    camera.framerate = 30
+    target_bitrate = camera.resolution[0] * \
+        camera.resolution[1] * \
+        camera.framerate * 0.150
+    camera.start_recording(
+        video_track,
+        format="h264",
+        profile="constrained",
+        bitrate=int(target_bitrate),  # From wowza recommended settings
+        inline_headers=True,
+        sei=False,
+    )
+    return video_track
+
+
+async def index(request):
+    content = open(os.path.join(ROOT, "index.html"), "r").read()
+    return web.Response(content_type="text/html", text=content)
+
+
+async def javascript(request):
+    content = open(os.path.join(ROOT, "client.js"), "r").read()
+    return web.Response(content_type="application/javascript", text=content)
+
+
+async def offer(request):
+
+    params = await request.json()
+    offer = RTCSessionDescription(sdp=params["sdp"], type=params["type"])
+
+    pc = RTCPeerConnection()
+    pcs.add(pc)
+
+    @pc.on("iceconnectionstatechange")
+    async def on_iceconnectionstatechange():
+        print("ICE connection state is %s" % pc.iceConnectionState)
+        if pc.iceConnectionState == "failed":
+            await pc.close()
+            pcs.discard(pc)
+
+    video = create_pi_track()
+
+    transceiver = pc.addTransceiver("video")
+    capabilities = RTCRtpSender.getCapabilities("video")
+    preferences = list(filter(lambda x: x.name == "H264", capabilities.codecs))
+    preferences += list(filter(lambda x: x.name == "rtx", capabilities.codecs))
+    transceiver.setCodecPreferences(preferences)
+
+    await pc.setRemoteDescription(offer)
+    for t in pc.getTransceivers():
+        if t.kind == "video":
+            pc.addTrack(video)
+    answer = await pc.createAnswer()
+    await pc.setLocalDescription(answer)
+    print(answer)
+    return web.Response(
+        content_type="application/json",
+        text=json.dumps(
+            {"sdp": pc.localDescription.sdp, "type": pc.localDescription.type}
+        ),
+    )
+
+
+pcs = set()
+
+
+async def on_shutdown(app):
+    global camera
+    # close peer connections
+    print("Shutting down")
+    coros = [pc.close() for pc in pcs]
+    await asyncio.gather(*coros)
+    pcs.clear()
+    camera.stop_recording()
+
+
+if __name__ == "__main__":
+    ssl_context = None
+    app = web.Application()
+    app.on_shutdown.append(on_shutdown)
+    app.router.add_get("/", index)
+    app.router.add_get("/client.js", javascript)
+    app.router.add_post("/offer", offer)
+    web.run_app(app, host="0.0.0.0", port=8080, ssl_context=ssl_context)

--- a/examples/picamera/pitrack.py
+++ b/examples/picamera/pitrack.py
@@ -1,0 +1,182 @@
+import asyncio
+import math
+from queue import Queue
+from struct import pack
+from typing import Iterator, List, Tuple
+
+from aiortc.mediastreams import EncodedMediaStreamTrack
+
+PACKET_MAX = 1300
+
+NAL_TYPE_FU_A = 28
+NAL_TYPE_STAP_A = 24
+
+NAL_HEADER_SIZE = 1
+FU_A_HEADER_SIZE = 2
+LENGTH_FIELD_SIZE = 2
+STAP_A_HEADER_SIZE = NAL_HEADER_SIZE + LENGTH_FIELD_SIZE
+
+
+class PiH264StreamTrack(EncodedMediaStreamTrack):
+
+    kind = "video"
+
+    _start: float
+    _timestamp: int
+
+    def __init__(self, video_rate, clock_rate=90000) -> None:
+        super().__init__()
+        self.nal_queue = Queue(3)
+        self._timestamp = 0
+        self._frame_time = 1 / video_rate
+        self._clock_rate = clock_rate
+        self.nal_buffer = None
+
+    def write(self, buf: bytes):
+        if self.nal_buffer is None:
+            self.nal_buffer = buf
+        else:
+            self.nal_buffer += buf
+        if (
+            len(self.nal_buffer) < 64
+        ):  # Just making sure to pack SPS/PPS within a single buffer
+            return
+        if not self.nal_queue.full():
+            self.nal_queue.put(self.nal_buffer)
+        self.nal_buffer = None
+
+    @staticmethod
+    def _packetize_fu_a(data: bytes) -> List[bytes]:
+        available_size = PACKET_MAX - FU_A_HEADER_SIZE
+        payload_size = len(data) - NAL_HEADER_SIZE
+        num_packets = math.ceil(payload_size / available_size)
+        num_larger_packets = payload_size % num_packets
+        package_size = payload_size // num_packets
+
+        f_nri = data[0] & (0x80 | 0x60)  # fni of original header
+        nal = data[0] & 0x1F
+
+        fu_indicator = f_nri | NAL_TYPE_FU_A
+
+        fu_header_end = bytes([fu_indicator, nal | 0x40])
+        fu_header_middle = bytes([fu_indicator, nal])
+        fu_header_start = bytes([fu_indicator, nal | 0x80])
+        fu_header = fu_header_start
+
+        packages = []
+        offset = NAL_HEADER_SIZE
+        while offset < len(data):
+            if num_larger_packets > 0:
+                num_larger_packets -= 1
+                payload = data[offset : offset + package_size + 1]
+                offset += package_size + 1
+            else:
+                payload = data[offset : offset + package_size]
+                offset += package_size
+
+            if offset == len(data):
+                fu_header = fu_header_end
+
+            packages.append(fu_header + payload)
+
+            fu_header = fu_header_middle
+        assert offset == len(data), "incorrect fragment data"
+
+        return packages
+
+    @staticmethod
+    def _packetize_stap_a(
+        data: bytes, packages_iterator: Iterator[bytes]
+    ) -> Tuple[bytes, bytes]:
+        counter = 0
+        available_size = PACKET_MAX - STAP_A_HEADER_SIZE
+
+        stap_header = NAL_TYPE_STAP_A | (data[0] & 0xE0)
+
+        payload = bytes()
+        try:
+            nalu = data  # with header
+            while len(nalu) <= available_size and counter < 9:
+                stap_header |= nalu[0] & 0x80
+
+                nri = nalu[0] & 0x60
+                if stap_header & 0x60 < nri:
+                    stap_header = stap_header & 0x9F | nri
+
+                available_size -= LENGTH_FIELD_SIZE + len(nalu)
+                counter += 1
+                payload += pack("!H", len(nalu)) + nalu
+                nalu = next(packages_iterator)
+
+            if counter == 0:
+                nalu = next(packages_iterator)
+        except StopIteration:
+            nalu = None
+
+        if counter <= 1:
+            return data, nalu
+        else:
+            return bytes([stap_header]) + payload, nalu
+
+    @classmethod
+    def _packetize(cls, packages: Iterator[bytes]) -> List[bytes]:
+        packetized_packages = []
+
+        packages_iterator = iter(packages)
+        package = next(packages_iterator, None)
+        while package is not None:
+            if len(package) > PACKET_MAX:
+                packetized_packages.extend(cls._packetize_fu_a(package))
+                package = next(packages_iterator, None)
+            else:
+                packetized, package = cls._packetize_stap_a(package, packages_iterator)
+                packetized_packages.append(packetized)
+
+        return packetized_packages
+
+    @staticmethod
+    def _split_bitstream(buf: bytes) -> Iterator[bytes]:
+        # TODO: write in a more pytonic way,
+        # translate from: https://github.com/aizvorski/h264bitstream/blob/master/h264_nal.c#L134
+        i = 0
+        while True:
+            while (buf[i] != 0 or buf[i + 1] != 0 or buf[i + 2] != 0x01) and (
+                buf[i] != 0 or buf[i + 1] != 0 or buf[i + 2] != 0 or buf[i + 3] != 0x01
+            ):
+                i += 1  # skip leading zero
+                if i + 4 >= len(buf):
+                    return
+            if buf[i] != 0 or buf[i + 1] != 0 or buf[i + 2] != 0x01:
+                i += 1
+            i += 3
+            nal_start = i
+            if (buf[nal_start] & 0x1F) != 7 and (
+                buf[nal_start] & 0x1F
+            ) != 8:  # Assuming only SPS/PPS are packaged with other NALs
+                yield buf[nal_start:]
+                return
+            while (buf[i] != 0 or buf[i + 1] != 0 or buf[i + 2] != 0) and (
+                buf[i] != 0 or buf[i + 1] != 0 or buf[i + 2] != 0x01
+            ):
+                i += 1
+                # FIXME: the next line fails when reading a nal that ends
+                # exactly at the end of the data
+                if i + 3 >= len(buf):
+                    nal_end = len(buf)
+                    yield buf[nal_start:]
+                    return  # did not find nal end, stream ended first
+            nal_end = i
+            yield buf[nal_start:nal_end]
+
+    async def recv_encoded(self, keyframe=False) -> List[bytes]:
+        while True:
+            if self.nal_queue.empty():
+                await asyncio.sleep(self._frame_time)
+                continue
+            nal = self.nal_queue.get()
+            #if (nal[4] & 0x1F) != 0x01 or not keyframe:
+            #    break
+            break
+        self._timestamp += int(self._frame_time * self._clock_rate)
+        timestamp = self._timestamp
+        return self._packetize(self._split_bitstream(nal)), timestamp

--- a/src/aiortc/mediastreams.py
+++ b/src/aiortc/mediastreams.py
@@ -3,7 +3,7 @@ import fractions
 import time
 import uuid
 from abc import ABCMeta, abstractmethod
-from typing import Tuple
+from typing import List, Tuple
 
 from av import AudioFrame, VideoFrame
 from av.frame import Frame
@@ -144,3 +144,22 @@ class VideoStreamTrack(MediaStreamTrack):
         frame.pts = pts
         frame.time_base = time_base
         return frame
+
+
+class EncodedMediaStreamTrack(MediaStreamTrack):
+    """
+    A single encoded media track within a stream.
+    """
+
+    kind = "unknown"
+
+    def __init__(self) -> None:
+        super().__init__()
+        self.keyframe = False
+
+    async def recv(self) -> Frame:
+        return None
+
+    @abstractmethod
+    async def recv_encoded(self, keyframe: bool) -> Tuple[List[bytes], int]:
+        pass

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -10,7 +10,11 @@ from . import clock, rtp
 from .codecs import get_capabilities, get_encoder, is_rtx
 from .codecs.base import Encoder
 from .exceptions import InvalidStateError
-from .mediastreams import MediaStreamError, MediaStreamTrack
+from .mediastreams import (
+    EncodedMediaStreamTrack, 
+    MediaStreamError, 
+    MediaStreamTrack,
+)
 from .rtcrtpparameters import RTCRtpCodecParameters, RTCRtpSendParameters
 from .rtp import (
     RTCP_PSFB_APP,
@@ -244,17 +248,19 @@ class RTCRtpSender:
                 pass
 
     async def _next_encoded_frame(self, codec: RTCRtpCodecParameters):
-        # get frame
-        frame = await self.__track.recv()
-
-        # encode frame
-        if self.__encoder is None:
-            self.__encoder = get_encoder(codec)
-        force_keyframe = self.__force_keyframe
-        self.__force_keyframe = False
-        return await self.__loop.run_in_executor(
-            None, self.__encoder.encode, frame, force_keyframe
-        )
+        if isinstance(self.__track, EncodedMediaStreamTrack):
+            force_keyframe = self.__force_keyframe
+            self.__force_keyframe = False
+            return await self.__track.recv_encoded(force_keyframe)
+        else:
+            frame = await self.__track.recv()
+            if self.__encoder is None:
+                self.__encoder = get_encoder(codec)
+            force_keyframe = self.__force_keyframe
+            self.__force_keyframe = False
+            return await self.__loop.run_in_executor(
+                None, self.__encoder.encode, frame, force_keyframe
+            )
 
     async def _retransmit(self, sequence_number: int) -> None:
         """


### PR DESCRIPTION
This pull request adds the ability to use a pre-encoded track (tested with H264) without re-encoding. This is especially useful for small targets that implement the H264 encoding directly in the video pipeline with zero copy to the CPU. It can also be used with webcam that outputs an h264 encoded stream, IP cameras or any embedded platform that provides only gstreamer support to access the hardware video encoder. The patch to the aiortc code does not disturb original behavior and its left to the user to implement the H264 stream parsing (see picamera example).