### PR TITLE
Fix webcam.py example run instruction

### DIFF
--- a/examples/webcam/README.rst
+++ b/examples/webcam/README.rst
@@ -34,7 +34,7 @@ If you want to play a media file instead of using the webcam, run:
 
 .. code-block:: console
 
-   $ python server.py --play-from video.mp4
+   $ python webcam.py --play-from video.mp4
 
 Credits
 -------


### PR DESCRIPTION
Fix run instruction for playing from a media file: `server.py` to `webcam.py`