### PR TITLE
connectionstatechange should be emitted when remote is closing the co…

### DIFF
--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -1128,7 +1128,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         # NOTE: we do not have a "disconnected" state
         dtlsStates = set(map(lambda x: x.state, self.__dtlsTransports))
         iceStates = set(map(lambda x: x.state, self.__iceTransports))
-        if self.__isClosed:
+        if self.__isClosed or "closed" in iceStates or "closed" in dtlsStates:
             state = "closed"
         elif "failed" in iceStates or "failed" in dtlsStates:
             state = "failed"


### PR DESCRIPTION
I couldn't figure out why I couldn't catch the "closed" state when the remote peer was closing the connection. The connectionstatechange event is not emitted for this use case. 
When the remote peer close the connection dtlsStates contains ({'closed'},) so we should also emit the connectionstatechange event.