### PR TITLE
Cancel track task in MediaRelay

### DIFF
--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -460,6 +460,7 @@ class MediaRelay:
         if track is not None and track in self.__proxies:
             # unregister proxy
             self.__log_debug("Stop proxy %s", id(proxy))
+            self.__tasks[track].cancel()
             self.__proxies[track].discard(proxy)
 
     def __log_debug(self, msg: str, *args) -> None:

--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -1128,7 +1128,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         # NOTE: we do not have a "disconnected" state
         dtlsStates = set(map(lambda x: x.state, self.__dtlsTransports))
         iceStates = set(map(lambda x: x.state, self.__iceTransports))
-        if self.__isClosed:
+        if self.__isClosed or "closed" in iceStates or "closed" in dtlsStates:
             state = "closed"
         elif "failed" in iceStates or "failed" in dtlsStates:
             state = "failed"


### PR DESCRIPTION
I was getting the following error when terminating a running program: 
2021-11-29 20:17:28,559 ERROR    Task was destroyed but it is pending!
It seemed the actual task was never cancelled. 