### PR TITLE
Add support for looping to MediaPlayer

### DIFF
--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -82,7 +82,14 @@ class MediaBlackhole:
 
 
 def player_worker(
-    loop, container, streams, audio_track, video_track, quit_event, throttle_playback
+    loop,
+    container,
+    streams,
+    audio_track,
+    video_track,
+    quit_event,
+    throttle_playback,
+    loop_playback,
 ):
     audio_fifo = av.AudioFifo()
     audio_format_name = "s16"
@@ -105,6 +112,9 @@ def player_worker(
         except (av.AVError, StopIteration) as exc:
             if isinstance(exc, av.FFmpegError) and exc.errno == errno.EAGAIN:
                 time.sleep(0.01)
+                continue
+            if isinstance(exc, StopIteration) and loop_playback:
+                container.seek(0)
                 continue
             if audio_track:
                 asyncio.run_coroutine_threadsafe(audio_track._queue.put(None), loop)
@@ -232,9 +242,10 @@ class MediaPlayer:
     :param file: The path to a file, or a file-like object.
     :param format: The format to use, defaults to autodect.
     :param options: Additional options to pass to FFmpeg.
+    :param loop: Whether to repeat playback indefinitely (requires a seekable file).
     """
 
-    def __init__(self, file, format=None, options={}):
+    def __init__(self, file, format=None, options={}, loop=False):
         self.__container = av.open(file=file, format=format, mode="r", options=options)
         self.__thread: Optional[threading.Thread] = None
         self.__thread_quit: Optional[threading.Event] = None
@@ -255,6 +266,12 @@ class MediaPlayer:
         # check whether we need to throttle playback
         container_format = set(self.__container.format.name.split(","))
         self._throttle_playback = not container_format.intersection(REAL_TIME_FORMATS)
+
+        # check whether the looping is supported
+        assert (
+            not loop or self.__container.duration is not None
+        ), "The `loop` argument requires a seekable file"
+        self._loop_playback = loop
 
     @property
     def audio(self) -> MediaStreamTrack:
@@ -286,6 +303,7 @@ class MediaPlayer:
                     self.__video,
                     self.__thread_quit,
                     self._throttle_playback,
+                    self._loop_playback,
                 ),
             )
             self.__thread.start()

--- a/tests/test_contrib_media.py
+++ b/tests/test_contrib_media.py
@@ -389,6 +389,26 @@ class MediaPlayerTest(MediaTestCase):
             run(player.audio.recv())
         self.assertEqual(player.audio.readyState, "ended")
 
+    def test_audio_file_looping(self):
+        path = self.create_audio_file("test.wav", sample_rate=48000)
+        player = MediaPlayer(path, loop=True)
+
+        # read all frames, then loop and re-read all frames
+        self.assertEqual(player.audio.readyState, "live")
+        for i in range(100):
+            frame = run(player.audio.recv())
+            self.assertEqual(frame.format.name, "s16")
+            self.assertEqual(frame.layout.name, "stereo")
+            self.assertEqual(frame.samples, 960)
+            self.assertEqual(frame.sample_rate, 48000)
+
+        # read one more time, forcing a second loop
+        run(player.audio.recv())
+        self.assertEqual(player.audio.readyState, "live")
+
+        # stop the player
+        player.audio.stop()
+
     def test_audio_and_video_file(self):
         path = self.create_audio_and_video_file(name="test.mp4", duration=5)
         player = MediaPlayer(path)


### PR DESCRIPTION
e.g., `player = MediaPlayer("foo.mp3", loop=True)` results in continuous playback. This is useful for bots and other sorts of testing.