### PR TITLE
[rtcp] limit size of NACK reports (fixes: #584)

### DIFF
--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -26,6 +26,7 @@ from .rtp import (
     RTCP_PSFB_APP,
     RTCP_PSFB_PLI,
     RTCP_RTPFB_NACK,
+    RTP_HISTORY_SIZE,
     AnyRtcpPacket,
     RtcpByePacket,
     RtcpPsfbPacket,
@@ -78,6 +79,9 @@ class NackGenerator:
         self.missing: Set[int] = set()
 
     def add(self, packet: RtpPacket) -> bool:
+        """
+        Mark a new packet as received, and deduce missing packets.
+        """
         missed = False
 
         if self.max_seq is None:
@@ -95,7 +99,22 @@ class NackGenerator:
         else:
             self.missing.discard(packet.sequence_number)
 
+        # limit number of tracked packets
+        self.truncate()
+
         return missed
+
+    def truncate(self) -> None:
+        """
+        Limit the number of missing packets we track.
+
+        Otherwise, the size of RTCP FB messages grows indefinitely.
+        """
+        if self.max_seq is not None:
+            min_seq = uint16_add(self.max_seq, -RTP_HISTORY_SIZE)
+            for seq in list(self.missing):
+                if uint16_gt(min_seq, seq):
+                    self.missing.discard(seq)
 
 
 class StreamStatistics:
@@ -553,7 +572,7 @@ class RTCRtpReceiver:
         except ConnectionError:
             pass
 
-    async def _send_rtcp_nack(self, media_ssrc: int, lost) -> None:
+    async def _send_rtcp_nack(self, media_ssrc: int, lost: List[int]) -> None:
         """
         Send an RTCP packet to report missing RTP packets.
         """

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -18,6 +18,7 @@ from .rtp import (
     RTCP_PSFB_APP,
     RTCP_PSFB_PLI,
     RTCP_RTPFB_NACK,
+    RTP_HISTORY_SIZE,
     AnyRtcpPacket,
     RtcpByePacket,
     RtcpPsfbPacket,
@@ -40,7 +41,6 @@ from .utils import random16, random32, uint16_add, uint32_add
 
 logger = logging.getLogger(__name__)
 
-RTP_HISTORY_SIZE = 128
 RTT_ALPHA = 0.85
 
 

--- a/src/aiortc/rtp.py
+++ b/src/aiortc/rtp.py
@@ -9,6 +9,9 @@ from av import AudioFrame
 
 from .rtcrtpparameters import RTCRtpParameters
 
+# used for NACK and retransmission
+RTP_HISTORY_SIZE = 128
+
 # reserved to avoid confusion with RTCP
 FORBIDDEN_PAYLOAD_TYPES = range(72, 77)
 DYNAMIC_PAYLOAD_TYPES = range(96, 128)

--- a/tests/test_rtcrtpreceiver.py
+++ b/tests/test_rtcrtpreceiver.py
@@ -110,6 +110,17 @@ class NackGeneratorTest(TestCase):
         self.assertEqual(missed, False)
         self.assertEqual(generator.missing, set())
 
+    def test_with_loss_truncate(self):
+        generator = NackGenerator()
+        packets = create_rtp_packets(259, 0)
+
+        generator.add(packets[0])
+        generator.add(packets[129])
+        self.assertEqual(generator.missing, set(range(1, 129)))
+
+        generator.add(packets[258])
+        self.assertEqual(generator.missing, set(range(130, 258)))
+
 
 class StreamStatisticsTest(TestCase):
     def create_counter(self):
@@ -396,9 +407,7 @@ class RTCRtpReceiverTest(CodecTestCase):
             await receiver._handle_rtp_packet(packets[128], arrival_time_ms=0)
 
             # check NACK was triggered
-            lost_packets = []
-            for i in range(127):
-                lost_packets.append(i + 1)
+            lost_packets = list(range(1, 128))
             self.assertEqual(nacks[0], (1234, lost_packets))
 
             # check PLI was triggered


### PR DESCRIPTION
We only keep track of the latest missing packets, it makes no sense to trigger
retransmission on older packets.