### PR TITLE
webcam example does not need OpenCV

### DIFF
--- a/examples/webcam/README.rst
+++ b/examples/webcam/README.rst
@@ -11,7 +11,7 @@ First install the required packages:
 
 .. code-block:: console
 
-    $ pip install aiohttp aiortc opencv-python
+    $ pip install aiohttp aiortc
 
 When you start the example, it will create an HTTP server which you
 can connect to from your browser:


### PR DESCRIPTION
Hi and thank you for this great library.

As stated in the PR title, I noticed `opencv-python` is not needed to run the `webcam` example, right?

(I figured this small documentation change does not warrant to open an issue and went ahead with this PR.)
