### PR TITLE
fix: adjusting regex for stun url

### DIFF
--- a/src/aiortc/rtcicetransport.py
+++ b/src/aiortc/rtcicetransport.py
@@ -12,6 +12,9 @@ from .rtcconfiguration import RTCIceServer
 
 STUN_REGEX = re.compile(
     r"(?P<scheme>stun|stuns)\:(?P<host>[^?:]+)(\:(?P<port>[0-9]+?))?"
+    # RFC 7064 does not define a "transport" option but some providers
+    # include it, so just ignore it
+    r"(\?transport=.*)?"
 )
 TURN_REGEX = re.compile(
     r"(?P<scheme>turn|turns)\:(?P<host>[^?:]+)(\:(?P<port>[0-9]+?))?"

--- a/tests/test_rtcicetransport.py
+++ b/tests/test_rtcicetransport.py
@@ -37,6 +37,14 @@ class ConnectionKwargsTest(TestCase):
             {"stun_server": ("stun.l.google.com", 19302)},
         )
 
+    def test_stun_with_suffix(self):
+        self.assertEqual(
+            connection_kwargs(
+                [RTCIceServer("stun:global.stun.twilio.com:3478?transport=udp")]
+            ),
+            {"stun_server": ("global.stun.twilio.com", 3478)},
+        )
+
     def test_stun_multiple_servers(self):
         self.assertEqual(
             connection_kwargs(


### PR DESCRIPTION
I am using private stun/turn servers (e.g. Twilio). I noticed that stun url is not according with regex: `stun:global.stun.twilio.com:3478?transport=udp`. This PR is a suggestion to fix this behavior. Follow [Twilio docs for more detail](https://www.twilio.com/docs/stun-turn). 