### PR TITLE
Fix slow datachannel sending (fixes: #776)

### DIFF
--- a/src/aiortc/rtcsctptransport.py
+++ b/src/aiortc/rtcsctptransport.py
@@ -1648,7 +1648,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
         if self._association_state != self.State.ESTABLISHED:
             return
 
-        while self._data_channel_queue and not self._outbound_queue:
+        while self._data_channel_queue:
             channel, protocol, user_data = self._data_channel_queue.popleft()
 
             # register channel if necessary


### PR DESCRIPTION
It looks like the second check in https://github.com/aiortc/aiortc/blob/1.3.2/src/aiortc/rtcsctptransport.py#L1651 erroneously breaks the loop in the very beginning and is redundant.