### PR TITLE
Always try to transmit data messages immediately. Fixes #776 and #547

### DIFF
--- a/src/aiortc/rtcsctptransport.py
+++ b/src/aiortc/rtcsctptransport.py
@@ -1324,8 +1324,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
             self._outbound_stream_seq[stream_id] = uint16_add(stream_seq, 1)
 
         # transmit outbound data
-        if not self._t3_handle:
-            await self._transmit()
+        await self._transmit()
 
     async def _send_chunk(self, chunk: Chunk) -> None:
         """


### PR DESCRIPTION
Instead of waiting for the next reception confirmation / empty in-flight queue Fixes aiortc#776, fixes aiortc#547
Superseeds #777

In my opinion, this is the correct way to fix the datachannel latency problems.

Without this modification, sending messages appends them to the buffer, but does not transmit them if Timer 3 `_t3_handle` is active (aka. there currently are other messages in-flight).  
`_transmit` will only get called once a reception confirmation for older messages is received.

As far as I understand it, `_t3_handle` timer is meant to handle abortion & retransmits of non-acknowledged data chunks and NOT meant to lock down transmission of data.
`_transmit()` internally handles the maximum amount of in-flight packages and if that overflows, the `_outbound_queue` will not get cleared and thus the `_data_channel_queue` also will start filling up and all the feedback (eg. `RTCDataChannel.bufferedAmount`) will work like intended.

