### PR TITLE
Implement force_keyframe parameter in h264

### DIFF
--- a/src/aiortc/codecs/h264.py
+++ b/src/aiortc/codecs/h264.py
@@ -278,8 +278,12 @@ class H264Encoder(Encoder):
             self.buffer_pts = None
             self.codec = None
 
-        # reset the picture type, otherwise no B-frames are produced
-        frame.pict_type = av.video.frame.PictureType.NONE
+        if force_keyframe:
+            # force a complete image
+            frame.pict_type = av.video.frame.PictureType.I
+        else:
+            # reset the picture type, otherwise no B-frames are produced
+            frame.pict_type = av.video.frame.PictureType.NONE
 
         if self.codec is None:
             try:

--- a/tests/test_h264.py
+++ b/tests/test_h264.py
@@ -116,6 +116,28 @@ class H264Test(CodecTestCase):
         packages, timestamp = encoder.encode(frame)
         self.assertGreaterEqual(len(packages), 1)
 
+    def test_encoder_large(self):
+        encoder = get_encoder(H264_CODEC)
+        self.assertIsInstance(encoder, H264Encoder)
+
+        # first keyframe
+        frame = self.create_video_frame(width=1280, height=720, pts=0)
+        payloads, timestamp = encoder.encode(frame)
+        self.assertGreaterEqual(len(payloads), 3)
+        self.assertEqual(timestamp, 0)
+
+        # delta frame
+        frame = self.create_video_frame(width=1280, height=720, pts=3000)
+        payloads, timestamp = encoder.encode(frame)
+        self.assertEqual(len(payloads), 1)
+        self.assertEqual(timestamp, 3000)
+
+        # force keyframe
+        frame = self.create_video_frame(width=1280, height=720, pts=6000)
+        payloads, timestamp = encoder.encode(frame, force_keyframe=True)
+        self.assertGreaterEqual(len(payloads), 3)
+        self.assertEqual(timestamp, 6000)
+
     def test_encoder_pack(self):
         encoder = get_encoder(H264_CODEC)
         self.assertTrue(isinstance(encoder, H264Encoder))


### PR DESCRIPTION
The `force_keyframe` parameter was ignored in the `_encode_frame()` method in `h264.py`

This change sets the picture type to `I` when `force_keyframe` is `True`