### PR TITLE
[dtls] Use PyOpenSSL's API instead of low-level APIs

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,6 +26,7 @@ install_requires = [
     "google-crc32c>=1.1",
     "pyee>=9.0.0",
     "pylibsrtp>=0.5.6",
+    "pyopenssl>=23.0.0",
 ]
 
 extras_require = {

--- a/tests/test_rtcdtlstransport.py
+++ b/tests/test_rtcdtlstransport.py
@@ -3,8 +3,9 @@ import datetime
 from unittest import TestCase
 from unittest.mock import patch
 
+from OpenSSL import SSL
+
 from aiortc.rtcdtlstransport import (
-    DtlsError,
     RTCCertificate,
     RTCDtlsFingerprint,
     RTCDtlsParameters,
@@ -100,17 +101,6 @@ class RTCDtlsTransportTest(TestCase):
 
         self.assertEqual(stats_a.bytesSent, stats_b.bytesReceived)
         self.assertEqual(stats_b.bytesSent, stats_a.bytesReceived)
-
-    @patch("aiortc.rtcdtlstransport.lib.SSL_CTX_use_certificate")
-    @asynctest
-    async def test_broken_ssl(self, mock_use_certificate):
-        mock_use_certificate.return_value = 0
-
-        transport1, transport2 = dummy_ice_transport_pair()
-
-        certificate = RTCCertificate.generateCertificate()
-        with self.assertRaises(DtlsError):
-            RTCDtlsTransport(transport1, [certificate])
 
     @asynctest
     async def test_data(self):
@@ -395,16 +385,12 @@ class RTCDtlsTransportTest(TestCase):
         await session1.stop()
         await session2.stop()
 
-    @patch("aiortc.rtcdtlstransport.lib.SSL_do_handshake")
-    @patch("aiortc.rtcdtlstransport.lib.SSL_get_error")
-    @patch("aiortc.rtcdtlstransport.lib.ERR_get_error")
+    @patch("aiortc.rtcdtlstransport.SSL.Connection.do_handshake")
     @asynctest
-    async def test_handshake_error(
-        self, mock_err_get_error, mock_ssl_get_error, mock_do_handshake
-    ):
-        mock_err_get_error.side_effect = [0x2006D080, 0, 0]
-        mock_ssl_get_error.return_value = 1
-        mock_do_handshake.return_value = -1
+    async def test_handshake_error(self, mock_do_handshake):
+        mock_do_handshake.side_effect = SSL.Error(
+            [("SSL routines", "", "decryption failed or bad record mac")]
+        )
 
         transport1, transport2 = dummy_ice_transport_pair()
 


### PR DESCRIPTION
Until now we used a mix of `crytography` and direct calls to the OpenSSL bindings, which eventually broke. We now try to use only PyOpenSSL's Python API, with the exception of DTLS timeout handling which is not yet exposed by PyOpenSSL.