### PR TITLE
[package] Use pyOpenSSL >= 23.1.0 which supports DTLS timeouts

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ install_requires = [
     "google-crc32c>=1.1",
     "pyee>=9.0.0",
     "pylibsrtp>=0.5.6",
-    "pyopenssl>=23.0.0",
+    "pyopenssl>=23.1.0",
 ]
 
 extras_require = {


### PR DESCRIPTION
Support for DTLS timeouts was contributed upstream in PR https://github.com/pyca/pyopenssl/pull/1180 which was released in version 23.1.0, so we can remove our local implementation.