### PR TITLE
[package] Depend on aioice 0.9.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,7 +18,7 @@ cffi_modules = [
     "src/_cffi_src/build_vpx.py:ffibuilder",
 ]
 install_requires = [
-    "aioice>=0.8.0,<0.9.0",
+    "aioice>=0.9.0,<1.0.0",
     "av>=9.0.0,<11.0.0",
     "cffi>=1.0.0",
     "cryptography>=2.2",


### PR DESCRIPTION
This removes the dependency on `netifaces` (which is unmaintained) in favour of `ifaddr` (which does not require binary wheels). It also fixes some spurious state transitions due to checks being run twice.