### PR TITLE
add pulseaudio support to Mediarecorder

### DIFF
--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -429,7 +429,7 @@ class MediaRecorder:
         :param track: A :class:`aiortc.MediaStreamTrack`.
         """
         if track.kind == "audio":
-            if self.__container.format.name in ("wav", "alsa"):
+            if self.__container.format.name in ("wav", "alsa", "pulse"):
                 codec_name = "pcm_s16le"
             elif self.__container.format.name == "mp3":
                 codec_name = "mp3"


### PR DESCRIPTION
In my test scenario:

```python3
import os                                                                                                                                                                                                                         
import logging                                                                                                                                                                                                                    
import asyncio                                                                                                                                                                                                                    
from aiortc.contrib.media import MediaPlayer, MediaRecorder                                                                                                                                                                       
                                                                                                                                                                                                                                  
logging.basicConfig(level=logging.DEBUG)                                                                                                                                                                                          
                                                                                                                                                                                                                                  
loop = asyncio.new_event_loop()                                                                                                                                                                                                   
                                                                                                                                                                                                                                  
ROOT = os.path.dirname(__file__)                                                                                                                                                                                                  
                                                                                                                                                                                                                                  
async def main():                                                                                                                                                                                                                 
    player = MediaPlayer(os.path.join(ROOT, "demo-instruct.wav"))                                                                                                                                                                 
    speaker = MediaRecorder(                                                                                                                                                                                                      
        "alsa_output.usb-0d8c_USB_Sound_Device-00.analog-surround-51",                                                                                                                                                            
        format="pulse")                                                                                                                                                                                                           
                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                  
    speaker.addTrack(player.audio)                                                                                                                                                                                                
    await asyncio.sleep(3)                                                                                                                                                                                                        
    await speaker.start()                                                                                                                                                                                                         
                                                                                                                                                                                                                                  
                                                                                                                                                                                                                                  
loop.run_until_complete(main())                                                                                                                                                                                                   
loop.run_forever()  
```
pulse not run with aac  but pcm_s16le.

`pulsaudio --version`
pulseaudio 16.1