### PR TITLE
Add webcam selection list for ./examples/server/ example

### DIFF
--- a/examples/server/index.html
+++ b/examples/server/index.html
@@ -74,6 +74,10 @@
     <input id="use-stun" type="checkbox"/>
     <label for="use-stun">Use STUN server</label>
 </div>
+<div class="option">
+    <label for="camera-selection">Select camera</label>
+    <select id="camera-selection"></select>
+</div>
 
 <button id="start" onclick="start()">Start</button>
 <button id="stop" style="display: none" onclick="stop()">Stop</button>


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/16375702/234017610-e77bff6b-fbe8-4be2-9edc-491e1f6783df.png)

Developed as a workaround to test Realsense camera which first webcam is depth image in Y16 format which can't be sent
```
[10076:11:0424/164151.763473:ERROR:webrtc_video_track_source.cc(160)] We cannot send frame 
with storage type: format: PIXEL_FORMAT_Y16 storage_type:UNOWNED_MEMORY 
coded_size:640x480 visible_rect:0,0 640x480 natural_size:640x480 timestamp:22190317
[10076:11:0424/164151.763808:ERROR:(-1)] Check failed: false.
```