### PR TITLE
Update to webrtc_track_id function for handling case without msid-semantic

### DIFF
--- a/src/aiortc/sdp.py
+++ b/src/aiortc/sdp.py
@@ -561,11 +561,14 @@ class SessionDescription:
         assert media in self.media
         if media.msid is not None and " " in media.msid:
             bits = media.msid.split()
-            for group in self.msid_semantic:
-                if group.semantic == "WMS" and (
-                    bits[0] in group.items or "*" in group.items
-                ):
-                    return bits[1]
+            if len(self.msid_semantic):
+                for group in self.msid_semantic:
+                    if group.semantic == "WMS" and (
+                        bits[0] in group.items or "*" in group.items
+                    ):
+                        return bits[1]
+            else:
+                return bits[1]
         return None
 
     def __str__(self) -> str:


### PR DESCRIPTION
This pull request updates the webrtc_track_id function in the SessionDescription class, found within sdp.py.

The main change implemented is an additional check for the scenario where msid-semantic is not provided. The updated code adds a check for this scenario, and in such cases, it directly returns bits[1] as the track id.

Prior to this update, the function would return None in scenarios where msid-semantic is not present in OFFER, as it strictly expected at least a msid-semantic to return a track id when an msid was present. This change thus enhances the function's flexibility and robustness in handling cases where media streams have an msid but no msid-semantic field is present.

This change was needed on my side to be able to connect an aiortc peer to Livekit SFU: Livekit does provide an msid for each track, but does not provide the msid-semantic field.

After some research, I found that it seems that the msid-semantic is not required (and may have been obsoleted between draft 08 and 09 of RFC-8830, see references below).

Here's a breakdown of the changes:

    Added a condition to check if self.msid_semantic is non-empty.
    If self.msid_semantic is empty, bits[1] (track id) is directly returned.
    If self.msid_semantic is non-empty, the existing behavior is retained.

This update ensures that the webrtc_track_id function can handle all scenarios more effectively, returning a valid track id even in cases where msid-semantic is not present.

References:
- msid-semantic description in draft version 08:
    [RFC-8830 (draft#08)](https://datatracker.ietf.org/doc/html/draft-ietf-mmusic-msid-08#section-3)

- msid-semantic attribute removed in draft version 09:
    [RFC-8830 (draft#08)](https://datatracker.ietf.org/doc/html/draft-ietf-mmusic-msid-09#appendix-B.15)

