### PR TITLE
Cancel MediaRelay's consumer task when the last proxy is stopped

### DIFF
--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -578,6 +578,10 @@ class MediaRelay:
             # unregister proxy
             self.__log_debug("Stop proxy %s", id(proxy))
             self.__proxies[track].discard(proxy)
+            if len(self.__proxies[track]) == 0 and track in self.__tasks:
+                self.__tasks[track].cancel()
+                del self.__tasks[track]
+                del self.__proxies[track]
 
     def __log_debug(self, msg: str, *args) -> None:
         logger.debug(f"MediaRelay(%s) {msg}", id(self), *args)

--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -578,7 +578,9 @@ class MediaRelay:
             # unregister proxy
             self.__log_debug("Stop proxy %s", id(proxy))
             self.__proxies[track].discard(proxy)
-            if len(self.__proxies[track]) == 0 and track in self.__tasks:
+
+            # stop worker if this was the last proxy
+            if not self.__proxies[track] and track in self.__tasks:
                 self.__tasks[track].cancel()
 
     def __log_debug(self, msg: str, *args) -> None:

--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -580,8 +580,6 @@ class MediaRelay:
             self.__proxies[track].discard(proxy)
             if len(self.__proxies[track]) == 0 and track in self.__tasks:
                 self.__tasks[track].cancel()
-                del self.__tasks[track]
-                del self.__proxies[track]
 
     def __log_debug(self, msg: str, *args) -> None:
         logger.debug(f"MediaRelay(%s) {msg}", id(self), *args)
@@ -589,11 +587,15 @@ class MediaRelay:
     async def __run_track(self, track: MediaStreamTrack) -> None:
         self.__log_debug("Start reading source %s" % id(track))
 
+        task_cancelled_error = None
         while True:
             try:
                 frame = await track.recv()
             except MediaStreamError:
                 frame = None
+            except asyncio.CancelledError as e:
+                frame = None
+                task_cancelled_error = e
             for proxy in self.__proxies[track]:
                 if proxy._buffered:
                     proxy._queue.put_nowait(frame)
@@ -606,3 +608,6 @@ class MediaRelay:
         self.__log_debug("Stop reading source %s", id(track))
         del self.__proxies[track]
         del self.__tasks[track]
+
+        if task_cancelled_error:
+            raise task_cancelled_error


### PR DESCRIPTION
Stop the `MediaRelay.__run_track()` task when all the downstream relay tracks are stopped.
This is kind of optimization, not a bug fix.