### PR TITLE
Increase DTLS bios buffer size for large x509

### DIFF
--- a/src/aiortc/rtcdtlstransport.py
+++ b/src/aiortc/rtcdtlstransport.py
@@ -616,7 +616,7 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
         Flush outgoing data which OpenSSL put in our BIO to the transport.
         """
         try:
-            data = self.ssl.bio_read(1500)
+            data = self.ssl.bio_read(8192)
         except SSL.Error:
             data = b""
         if data:


### PR DESCRIPTION
Solves the issue https://github.com/aiortc/aiortc/issues/828 for large X509 certificate such as RSA 4096 in DTLS exchanges