### PR TITLE
Replace time.time to time.monotonic for the purpose of measuring elapsed time

### DIFF
--- a/examples/datachannel-cli/cli.py
+++ b/examples/datachannel-cli/cli.py
@@ -41,10 +41,10 @@ def current_stamp():
     global time_start
 
     if time_start is None:
-        time_start = time.time()
+        time_start = time.monotonic()
         return 0
     else:
-        return int((time.time() - time_start) * 1000000)
+        return int((time.monotonic() - time_start) * 1000000)
 
 
 async def run_answer(pc, signaling):

--- a/examples/datachannel-filexfer/filexfer.py
+++ b/examples/datachannel-filexfer/filexfer.py
@@ -36,7 +36,7 @@ async def run_answer(pc, signaling, filename):
 
     @pc.on("datachannel")
     def on_datachannel(channel):
-        start = time.time()
+        start = time.monotonic()
         octets = 0
 
         @channel.on("message")
@@ -47,7 +47,7 @@ async def run_answer(pc, signaling, filename):
                 octets += len(message)
                 fp.write(message)
             else:
-                elapsed = time.time() - start
+                elapsed = time.monotonic() - start
                 print(
                     "received %d bytes in %.1f s (%.3f Mbps)"
                     % (octets, elapsed, octets * 8 / elapsed / 1000000)

--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -106,7 +106,7 @@ def player_worker_decode(
     video_first_pts = None
 
     frame_time = None
-    start_time = time.time()
+    start_time = time.monotonic()
 
     while not quit_event.is_set():
         try:
@@ -126,7 +126,7 @@ def player_worker_decode(
 
         # read up to 1 second ahead
         if throttle_playback:
-            elapsed_time = time.time() - start_time
+            elapsed_time = time.monotonic() - start_time
             if frame_time and frame_time > elapsed_time + 1:
                 time.sleep(0.1)
 
@@ -167,7 +167,7 @@ def player_worker_demux(
 ):
     video_first_pts = None
     frame_time = None
-    start_time = time.time()
+    start_time = time.monotonic()
 
     while not quit_event.is_set():
         try:
@@ -189,7 +189,7 @@ def player_worker_demux(
 
         # read up to 1 second ahead
         if throttle_playback:
-            elapsed_time = time.time() - start_time
+            elapsed_time = time.monotonic() - start_time
             if frame_time and frame_time > elapsed_time + 1:
                 time.sleep(0.1)
 
@@ -247,9 +247,9 @@ class PlayerStreamTrack(MediaStreamTrack):
             and data_time is not None
         ):
             if self._start is None:
-                self._start = time.time() - data_time
+                self._start = time.monotonic() - data_time
             else:
-                wait = self._start + data_time - time.time()
+                wait = self._start + data_time - time.monotonic()
                 await asyncio.sleep(wait)
 
         return data

--- a/src/aiortc/mediastreams.py
+++ b/src/aiortc/mediastreams.py
@@ -93,10 +93,10 @@ class AudioStreamTrack(MediaStreamTrack):
 
         if hasattr(self, "_timestamp"):
             self._timestamp += samples
-            wait = self._start + (self._timestamp / sample_rate) - time.time()
+            wait = self._start + (self._timestamp / sample_rate) - time.monotonic()
             await asyncio.sleep(wait)
         else:
-            self._start = time.time()
+            self._start = time.monotonic()
             self._timestamp = 0
 
         frame = AudioFrame(format="s16", layout="mono", samples=samples)
@@ -124,10 +124,10 @@ class VideoStreamTrack(MediaStreamTrack):
 
         if hasattr(self, "_timestamp"):
             self._timestamp += int(VIDEO_PTIME * VIDEO_CLOCK_RATE)
-            wait = self._start + (self._timestamp / VIDEO_CLOCK_RATE) - time.time()
+            wait = self._start + (self._timestamp / VIDEO_CLOCK_RATE) - time.monotonic()
             await asyncio.sleep(wait)
         else:
-            self._start = time.time()
+            self._start = time.monotonic()
             self._timestamp = 0
         return self._timestamp, VIDEO_TIME_BASE
 

--- a/tests/test_contrib_media.py
+++ b/tests/test_contrib_media.py
@@ -323,7 +323,7 @@ class MediaRelayTest(MediaTestCase):
 
         # skip some frames
         timestamp = 5 * samples_per_frame
-        await asyncio.sleep(source._start + (timestamp / 8000) - time.time())
+        await asyncio.sleep(source._start + (timestamp / 8000) - time.monotonic())
 
         frame1, frame2 = await asyncio.gather(proxy1.recv(), proxy2.recv())
         self.assertEqual(frame1.format.name, "s16")

--- a/tests/test_mediastreams.py
+++ b/tests/test_mediastreams.py
@@ -28,10 +28,10 @@ class VideoPacketStreamTrack(MediaStreamTrack):
     async def next_timestamp(self) -> Tuple[int, fractions.Fraction]:
         if hasattr(self, "_timestamp"):
             self._timestamp += int(VIDEO_PTIME * VIDEO_CLOCK_RATE)
-            wait = self._start + (self._timestamp / VIDEO_CLOCK_RATE) - time.time()
+            wait = self._start + (self._timestamp / VIDEO_CLOCK_RATE) - time.monotonic()
             await asyncio.sleep(wait)
         else:
-            self._start = time.time()
+            self._start = time.monotonic()
             self._timestamp = 0
         return self._timestamp, VIDEO_TIME_BASE
 


### PR DESCRIPTION
`time.time()` is not guaranteed to be monotonic.
So `time.monotonic()` should be used instead to measure elapsed time by subtracting two timestamps.
(There is a similar method, `time.perf_counter()`, but it's for perf-measuring on short-running code blocks.)

Ref: https://www.webucator.com/article/python-clocks-explained/