### PR TITLE
Fix incompatible extension headers

### DIFF
--- a/src/aiortc/codecs/__init__.py
+++ b/src/aiortc/codecs/__init__.py
@@ -46,7 +46,7 @@ HEADER_EXTENSIONS: Dict[str, List[RTCRtpHeaderExtensionParameters]] = {
             id=1, uri="urn:ietf:params:rtp-hdrext:sdes:mid"
         ),
         RTCRtpHeaderExtensionParameters(
-            id=2, uri="http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+            id=3, uri="http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
         ),
     ],
 }


### PR DESCRIPTION
Bug description first: when using the `createOffer` method, a remote peer rejects the generated offer. Remote peer is a browser client (Brave - it's a Chromium-based browser), using AWS Kinesis Video Signalling as a signalling channel. My setup: frontend streams video for backend processing and receives analysis data via data channel (omitted here - confirmed to reproduce without it). 

Reason below (lines split by me for readability):
```
InvalidAccessError: Failed to execute 'setRemoteDescription' on 'RTCPeerConnection': 
Failed to set remote offer sdp: 
A BUNDLE group contains a codec collision for header extension id=2. The id must be the same across all bundled media descriptions
```

It's generated [here](https://chromium.googlesource.com/external/webrtc/+/refs/heads/master/pc/sdp_offer_answer.cc#397).

Here's the relevant [specification part](https://www.ietf.org/rfc/rfc5285.txt):

> In addition, as noted above, the IDs used MUST be unique for each stream type for a given media, or for the session for session-level declarations.

If you want to try this specific setup (beware that running a stream for a while may cost you a couple of bucks), you can do it using [this page](https://awslabs.github.io/amazon-kinesis-video-streams-webrtc-sdk-js/examples/index.html) (better clone it locally [from here](https://github.com/awslabs/amazon-kinesis-video-streams-webrtc-sdk-js)) by filling in AWS credentials, creating a channel and selecting "send video", "send audio" and "use trickle ICE". The backend client can be created as follows:

```
import asyncio
import json
import base64
import sys

import websockets
from aiortc import (
    RTCConfiguration,
    RTCIceCandidate,
    RTCIceServer,
    RTCPeerConnection,
    RTCSessionDescription,
)
from aiortc.contrib.media import MediaBlackhole
from aiortc.sdp import candidate_from_sdp, candidate_to_sdp
from aiortc.contrib.signaling import BYE

# Grab this from logs on the webpage after starting the master, section [MASTER] ICE servers
# Note that these expire quickly, copy and run immediately
SERVERS = [
  {
    "urls": "stun:stun.kinesisvideo.us-west-2.amazonaws.com:443"
  },
  {
    "urls": [
      "turn:35-85-155-98.t-e1255f99.kinesisvideo.us-west-2.amazonaws.com:443?transport=udp",
      "turns:35-85-155-98.t-e1255f99.kinesisvideo.us-west-2.amazonaws.com:443?transport=udp",
      "turns:35-85-155-98.t-e1255f99.kinesisvideo.us-west-2.amazonaws.com:443?transport=tcp"
    ],
    "username": "...",
    "credential": "..."
  },
  {
    "urls": [
      "turn:54-185-203-154.t-e1255f99.kinesisvideo.us-west-2.amazonaws.com:443?transport=udp",
      "turns:54-185-203-154.t-e1255f99.kinesisvideo.us-west-2.amazonaws.com:443?transport=udp",
      "turns:54-185-203-154.t-e1255f99.kinesisvideo.us-west-2.amazonaws.com:443?transport=tcp"
    ],
    "username": "...",
    "credential": "..."
  }
]

class WebsocketSignaling:
    def __init__(self, uri):
        self._uri = uri
        self._websocket = None

    @classmethod
    def object_from_string(cls, message_str):
        raw_message = json.loads(message_str)
        message = json.loads(base64.b64decode(raw_message['messagePayload']))
        if raw_message['messageType'] == 'SDP_ANSWER':
            return RTCSessionDescription(**message)
        elif raw_message['messageType'] == 'ICE_CANDIDATE':
            candidate = candidate_from_sdp(message['candidate'].split(':', 1)[1])
            candidate.sdpMid = message['sdpMid']
            candidate.sdpMLineIndex = message['sdpMLineIndex']
            return candidate
        else:
            return BYE

    @classmethod
    def object_to_string(cls, obj):
        if isinstance(obj, RTCSessionDescription):
            message = {
                'type': obj.type,
                'sdp': obj.sdp,
            }
        elif isinstance(obj, RTCIceCandidate):
            message = {
                'candidate': 'candidate:' + candidate_to_sdp(obj),
                'id': obj.sdpMid,
                'label': obj.sdpMLineIndex,
                'type': 'candidate',
            }
        else:
            message = {'type': 'bye'}

        raw_message = json.dumps(message, separators=(",", ":"))
        return json.dumps({
            'action': 'SDP_OFFER',
            'messagePayload': base64.b64encode(raw_message.encode()).decode(),
        }, separators=(",", ":"))

    async def connect(self):
        self._websocket = await websockets.connect(self._uri)

    async def close(self):
        if self._websocket is not None and self._websocket.open is True:
            await self.send(None)
            await self._websocket.close()

    async def receive(self):
        try:
            data = await self._websocket.recv()
        except asyncio.IncompleteReadError:
            print('Incomplete')
            return
        print('Received', data)
        if not data:
            return
        ret = self.object_from_string(data)
        if ret is None:
            print("remote host says good bye!")

        return ret

    async def send(self, descr):
        data = self.object_to_string(descr)
        print('Broadcasting', data)
        await self._websocket.send(data)


async def run(pc, recorder, signaling):
    @pc.on("track")
    def on_track(track):
        print("Receiving %s" % track.kind)
        recorder.addTrack(track)

    # connect signaling
    await signaling.connect()

    # send offer
    pc.addTransceiver('audio', direction='recvonly')
    pc.addTransceiver('video', direction='recvonly')
    await pc.setLocalDescription(await pc.createOffer())
    await signaling.send(pc.localDescription)

    # consume signaling
    while True:
        print('wait')
        obj = await signaling.receive()

        if isinstance(obj, RTCSessionDescription):
            await pc.setRemoteDescription(obj)
            await recorder.start()
        elif isinstance(obj, RTCIceCandidate):
            await pc.addIceCandidate(obj)
        elif obj is BYE:
            print("Exiting")
            break


if __name__ == "__main__":
    # Pass one argument to the script: signed websocket URI.
    # The easiest way to get it: open that webpage in another tab, 
    # uncheck "send video" and "send audio" and press 'Start viewer'.
    # In network inspector, find a URI with 101 code. It is not the
    # same as for master! Copy it. It is valid for 5 minutes.
    signaling = WebsocketSignaling(sys.argv[1])
    pc = RTCPeerConnection(
        RTCConfiguration([RTCIceServer(**u) for u in SERVERS])
    )
    recorder = MediaBlackhole()

    try:
        asyncio.run(run(pc=pc, recorder=recorder, signaling=signaling))
    except KeyboardInterrupt:
        pass
    finally:
        # cleanup
        asyncio.run(recorder.stop())
        asyncio.run(signaling.close())
        asyncio.run(pc.close())
```

However, the complexity of the setup above must be scaring you. To remove all irrelevant factors, I can confirm that things work as expected with this PR applied. To find an explanation of why this matters, follow the source code link for Chromium above. If you're still interested, I can share full code to get signed websocket URL and ICE server configuration in code, without copy&paste hell.


Here's an example of a generated offer:

```
v=0
o=- 3907177302 3907177302 IN IP4 0.0.0.0
s=-
t=0 0
a=group:BUNDLE 0 1
a=msid-semantic:WMS *
m=audio 34621 UDP/TLS/RTP/SAVPF 96 0 8
c=IN IP4 192.168.1.5
a=recvonly
a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
a=mid:0
a=msid:415724dc-d0d1-4937-9041-78b93a20a4d7 d2a1c3a2-2cb9-46a2-a469-2dc697d8c724
a=rtcp:9 IN IP4 0.0.0.0
a=rtcp-mux
a=ssrc:2272291359 cname:f9d69f10-f6a5-4e75-8056-fc30ea06ee38
a=rtpmap:96 opus/48000/2
a=rtpmap:0 PCMU/8000
a=rtpmap:8 PCMA/8000
a=candidate:d1af0ea537ca290ff47701c289960ed4 1 udp 2130706431 192.168.1.5 34621 typ host
a=candidate:580b5f32035da7f14a30ea7a8d826c67 1 udp 2130706431 172.17.0.1 36157 typ host
a=candidate:58cf7e5226c8d939e26a3bf2a5f515aa 1 udp 2130706431 192.168.112.1 54597 typ host
a=candidate:f8f445bcddc0efd0138c6be773a3e678 1 udp 2130706431 10.92.184.1 59561 typ host
a=candidate:0ad8db753210ce9554cf251a9e51e792 1 udp 1694498815 91.150.114.19 36157 typ srflx raddr 172.17.0.1 rport 36157
a=candidate:288b726619019ce047cca2dc81ebb235 1 udp 1694498815 91.150.114.19 59561 typ srflx raddr 10.92.184.1 rport 59561
a=candidate:1cd78baa1788db557b074dcb69a33396 1 udp 1694498815 91.150.114.19 34621 typ srflx raddr 192.168.1.5 rport 34621
a=candidate:e67d80b8ea9219eabec769a698cf4437 1 udp 1694498815 91.150.114.19 54597 typ srflx raddr 192.168.112.1 rport 54597
a=candidate:be6838ab6dda59aea30a5a79aebeeda3 1 udp 16777215 35.87.212.130 58496 typ relay raddr 192.168.1.5 rport 37231
a=end-of-candidates
a=ice-ufrag:58jK
a=ice-pwd:1cyjSCyexo8oA7OSR0mX0z
a=fingerprint:sha-256 CC:8B:7F:A1:EB:D7:58:2A:01:65:4E:50:F1:80:AA:E6:8A:BC:B4:BA:D9:0E:EA:98:1B:78:BF:A9:31:19:30:D5
a=setup:actpass
m=video 38352 UDP/TLS/RTP/SAVPF 97 98 99 100 101 102
c=IN IP4 192.168.1.5
a=recvonly
a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
a=mid:1
a=msid:415724dc-d0d1-4937-9041-78b93a20a4d7 be4a976a-1ec9-4e9f-a6b2-6d3d4eda60f3
a=rtcp:9 IN IP4 0.0.0.0
a=rtcp-mux
a=ssrc-group:FID 2411032280 1790581305
a=ssrc:2411032280 cname:f9d69f10-f6a5-4e75-8056-fc30ea06ee38
a=ssrc:1790581305 cname:f9d69f10-f6a5-4e75-8056-fc30ea06ee38
a=rtpmap:97 VP8/90000
a=rtcp-fb:97 nack
a=rtcp-fb:97 nack pli
a=rtcp-fb:97 goog-remb
a=rtpmap:98 rtx/90000
a=fmtp:98 apt=97
a=rtpmap:99 H264/90000
a=rtcp-fb:99 nack
a=rtcp-fb:99 nack pli
a=rtcp-fb:99 goog-remb
a=fmtp:99 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42001f
a=rtpmap:100 rtx/90000
a=fmtp:100 apt=99
a=rtpmap:101 H264/90000
a=rtcp-fb:101 nack
a=rtcp-fb:101 nack pli
a=rtcp-fb:101 goog-remb
a=fmtp:101 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
a=rtpmap:102 rtx/90000
a=fmtp:102 apt=101
a=candidate:d1af0ea537ca290ff47701c289960ed4 1 udp 2130706431 192.168.1.5 38352 typ host
a=candidate:580b5f32035da7f14a30ea7a8d826c67 1 udp 2130706431 172.17.0.1 33948 typ host
a=candidate:58cf7e5226c8d939e26a3bf2a5f515aa 1 udp 2130706431 192.168.112.1 53501 typ host
a=candidate:f8f445bcddc0efd0138c6be773a3e678 1 udp 2130706431 10.92.184.1 40059 typ host
a=candidate:288b726619019ce047cca2dc81ebb235 1 udp 1694498815 91.150.114.19 40059 typ srflx raddr 10.92.184.1 rport 40059
a=candidate:1cd78baa1788db557b074dcb69a33396 1 udp 1694498815 91.150.114.19 38352 typ srflx raddr 192.168.1.5 rport 38352
a=candidate:e67d80b8ea9219eabec769a698cf4437 1 udp 1694498815 91.150.114.19 53501 typ srflx raddr 192.168.112.1 rport 53501
a=candidate:0ad8db753210ce9554cf251a9e51e792 1 udp 1694498815 91.150.114.19 33948 typ srflx raddr 172.17.0.1 rport 33948
a=candidate:be6838ab6dda59aea30a5a79aebeeda3 1 udp 16777215 35.87.212.130 59074 typ relay raddr 192.168.1.5 rport 46683
a=end-of-candidates
a=ice-ufrag:GXMO
a=ice-pwd:I6NYy5zRgAt4N0Qr3BogXa
a=fingerprint:sha-256 CC:8B:7F:A1:EB:D7:58:2A:01:65:4E:50:F1:80:AA:E6:8A:BC:B4:BA:D9:0E:EA:98:1B:78:BF:A9:31:19:30:D5
a=setup:actpass
```

Pay attention to lines:

```
...
a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:2 urn:ietf:params:rtp-hdrext:ssrc-audio-level
...

a=extmap:1 urn:ietf:params:rtp-hdrext:sdes:mid
a=extmap:2 http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time
```