### PR TITLE
Fix src/aiortc/contrib/media.py not to use mutable object constructors as default values of method arguments

### DIFF
--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -300,7 +300,7 @@ class MediaPlayer:
     """
 
     def __init__(
-        self, file, format=None, options={}, timeout=None, loop=False, decode=True
+        self, file, format=None, options=None, timeout=None, loop=False, decode=True
     ):
         self.__container = av.open(
             file=file, format=format, mode="r", options=options, timeout=timeout
@@ -418,7 +418,7 @@ class MediaRecorder:
     :param options: Additional options to pass to FFmpeg.
     """
 
-    def __init__(self, file, format=None, options={}):
+    def __init__(self, file, format=None, options=None):
         self.__container = av.open(file=file, format=format, mode="w", options=options)
         self.__tracks = {}
 


### PR DESCRIPTION
Mutable objects must not be used as default values of arguments: https://stackoverflow.com/q/26320899/13103190