### PR TITLE
Use set_source_pkgconfig instead of set_source

### DIFF
--- a/src/_cffi_src/build_opus.py
+++ b/src/_cffi_src/build_opus.py
@@ -1,14 +1,13 @@
-from cffi import FFI
+import cffi
 
-ffibuilder = FFI()
+module_name = "aiortc.codecs._opus"
 
-ffibuilder.set_source(
-    "aiortc.codecs._opus",
-    """
-#include <opus/opus.h>
-    """,
-    libraries=["opus"],
-)
+ffibuilder = cffi.FFI()
+
+try:
+    ffibuilder.set_source_pkgconfig(module_name, ["opus"], "#include <opus.h>")
+except cffi.PkgConfigError:
+    ffibuilder.set_source(module_name, "#include <opus/opus.h>", libraries=["opus"])
 
 ffibuilder.cdef(
     """

--- a/src/_cffi_src/build_vpx.py
+++ b/src/_cffi_src/build_vpx.py
@@ -1,10 +1,7 @@
-from cffi import FFI
+import cffi
 
-ffibuilder = FFI()
-
-ffibuilder.set_source(
-    "aiortc.codecs._vpx",
-    """
+module_name = "aiortc.codecs._vpx"
+c_header_source = """
 #include <vpx/vpx_decoder.h>
 #include <vpx/vpx_encoder.h>
 #include <vpx/vp8cx.h>
@@ -28,9 +25,14 @@ vpx_codec_err_t vpx_codec_enc_init(vpx_codec_ctx_t *ctx,
 {
     return vpx_codec_enc_init_ver(ctx, iface, cfg, flags, VPX_ENCODER_ABI_VERSION);
 }
-    """,
-    libraries=["vpx"],
-)
+"""
+
+ffibuilder = cffi.FFI()
+
+try:
+    ffibuilder.set_source_pkgconfig(module_name, ["vpx"], c_header_source)
+except cffi.PkgConfigError:
+    ffibuilder.set_source(module_name, c_header_source, libraries=["vpx"])
 
 ffibuilder.cdef(
     """


### PR DESCRIPTION
I don't fully understanding how Python does FFI, but I don't understand how it would work before.

Now it uses pkg-config and will pull the header locations properly. 