### PR TITLE
Update binary opus / vpx codecs for wheels

### DIFF
--- a/scripts/fetch-vendor.json
+++ b/scripts/fetch-vendor.json
@@ -1,3 +1,3 @@
 {
-    "urls": ["https://github.com/aiortc/aiortc-codecs/releases/download/1.6/codecs-{platform}.tar.gz"]
+    "urls": ["https://github.com/aiortc/aiortc-codecs/releases/download/1.7/codecs-{platform}.tar.gz"]
 }


### PR DESCRIPTION
Upgrade:

 - opus to version 1.4
 - vpx to version 1.13.1 to fix CVE-2023-5217