### PR TITLE
Update DTLS cipher list

### DIFF
--- a/src/aiortc/rtcdtlstransport.py
+++ b/src/aiortc/rtcdtlstransport.py
@@ -191,7 +191,9 @@ class RTCCertificate:
         )
         ctx.use_certificate(self._cert)
         ctx.use_privatekey(self._key)
-        ctx.set_cipher_list(b"HIGH:!CAMELLIA:!aNULL")
+        ctx.set_cipher_list(
+            b"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA"
+        )
         ctx.set_tlsext_use_srtp(b":".join(x.openssl_profile for x in srtp_profiles))
 
         return ctx


### PR DESCRIPTION
Fix #956 

The current DTLS cipher suite setting is `HIGH:!CAMELLIA:!aNULL` , in which case the Client Hello fragmentation occurs.
Therefore, if a library that does not support the Client Hello fragmentation, such as Mbed TLS, is used, the handshake will fail.

This problem can be solved by aligning the cipher suite to the browser and reducing the number of cipher suites.

|<img width="1077" alt="before" src="https://github.com/aiortc/aiortc/assets/18162391/527ece9e-62bd-42fa-bfa1-a30fac9ece2b">|<img width="953" alt="after" src="https://github.com/aiortc/aiortc/assets/18162391/17a31d58-ab79-4360-8147-35f810b2198b">|
|:--:|:--:|
|before|after|

In my environment, the number of cipher suites sent by Client Hello is 12, as shown below, and I checked that fragmentation does not occur.