### PR TITLE
Fix `utcnow()` and `not_valid_after()` deprecation warnings

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,7 +29,7 @@ dependencies = [
     "aioice>=0.9.0,<1.0.0",
     "av>=9.0.0,<12.0.0",
     "cffi>=1.0.0",
-    "cryptography>=2.2",
+    "cryptography>=42.0.0",
     'dataclasses; python_version < "3.7"',
     "google-crc32c>=1.1",
     "pyee>=9.0.0",

--- a/src/aiortc/rtcdtlstransport.py
+++ b/src/aiortc/rtcdtlstransport.py
@@ -54,14 +54,15 @@ def generate_certificate(key: ec.EllipticCurvePrivateKey) -> x509.Certificate:
             )
         ]
     )
+    now = datetime.datetime.now(tz=datetime.timezone.utc)
     builder = (
         x509.CertificateBuilder()
         .subject_name(name)
         .issuer_name(name)
         .public_key(key.public_key())
         .serial_number(x509.random_serial_number())
-        .not_valid_before(datetime.datetime.utcnow() - datetime.timedelta(days=1))
-        .not_valid_after(datetime.datetime.utcnow() + datetime.timedelta(days=30))
+        .not_valid_before(now - datetime.timedelta(days=1))
+        .not_valid_after(now + datetime.timedelta(days=30))
     )
     return builder.sign(key, hashes.SHA256(), default_backend())
 
@@ -115,9 +116,7 @@ class RTCCertificate:
         """
         The date and time after which the certificate will be considered invalid.
         """
-        return self._cert.to_cryptography().not_valid_after.replace(
-            tzinfo=datetime.timezone.utc
-        )
+        return self._cert.to_cryptography().not_valid_after_utc
 
     def getFingerprints(self) -> List[RTCDtlsFingerprint]:
         """


### PR DESCRIPTION
As of Python 3.12, `datetime.datetime.utcnow()` is deprecated in favour of passing a timezone to `datetime.datetime.now()`. `cryptography` has also made their `datetime` handling timezone-aware so adapt to the new API.