### PR TITLE
Bump required pylibsrtp version to 0.10.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,7 @@ dependencies = [
     'dataclasses; python_version < "3.7"',
     "google-crc32c>=1.1",
     "pyee>=9.0.0",
-    "pylibsrtp>=0.5.6",
+    "pylibsrtp>=0.10.0",
     "pyopenssl>=24.0.0",
 ]
 dynamic = ["version"]

--- a/src/aiortc/rtcdtlstransport.py
+++ b/src/aiortc/rtcdtlstransport.py
@@ -82,7 +82,7 @@ for srtp_profile in [
 ]:
     try:
         Policy(srtp_profile=srtp_profile.libsrtp_profile)
-    except pylibsrtp.Error:
+    except pylibsrtp.Error:  # pragma: no cover
         pass
     else:
         SRTP_PROFILES.append(srtp_profile)


### PR DESCRIPTION
This allows us to ensure GCM is available when installing `pylibsrtp` from binary wheels.