### PR TITLE
Free encoder when RTCRtpSender finishes

### DIFF
--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -371,6 +371,10 @@ class RTCRtpSender:
             self.__track.stop()
             self.__track = None
 
+        # release encoder
+        if self.__encoder:
+            del self.__encoder
+
         self.__log_debug("- RTP finished")
         self.__rtp_exited.set()
 


### PR DESCRIPTION
Once an `RTCRtpSender` stops, free the encoder as it may consume a considerable amount of memory.

Fixes: #925