### PR TITLE
Include musllinux builds

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -124,7 +124,6 @@ jobs:
           CIBW_BEFORE_BUILD_WINDOWS: python scripts\fetch-vendor.py C:\cibw\vendor
           CIBW_ENVIRONMENT: CFLAGS=-I/tmp/vendor/include LDFLAGS=-L/tmp/vendor/lib
           CIBW_ENVIRONMENT_WINDOWS: INCLUDE=C:\\cibw\\vendor\\include LIB=C:\\cibw\\vendor\\lib
-          CIBW_SKIP: '*-musllinux*'
         run: |
           pip install cibuildwheel
           cibuildwheel --output-dir dist


### PR DESCRIPTION
Removes the filter to include `musllinux` builds for Alpine, which is very popular for containers, and more. In my case I need it specifically for Home Assistant. [Tested it](https://github.com/TECH7Fox/aiortc/actions/runs/8027902526) and the CI runs fine and includes the additional `musllinux` wheels.

Was there a reason to originally exclude it?