### PR TITLE
enable|disable RTCRtpSender and RTCRtpReceiver

### DIFF
--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -789,7 +789,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         # configure direction
         for t in self.__transceivers:
             if description.type in ["answer", "pranswer"]:
-                t._currentDirection = and_direction(t.direction, t._offerDirection)
+                t._setCurrentDirection(and_direction(t.direction, t._offerDirection))
 
         # gather candidates
         await self.__gather()
@@ -871,7 +871,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
                 # configure direction
                 direction = reverse_direction(media.direction)
                 if description.type in ["answer", "pranswer"]:
-                    transceiver._currentDirection = direction
+                    transceiver._setCurrentDirection(direction)
                 else:
                     transceiver._offerDirection = direction
 

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -263,6 +263,7 @@ class RTCRtpReceiver:
         if transport.state == "closed":
             raise InvalidStateError
 
+        self._enabled = True
         self.__active_ssrc: Dict[int, datetime.datetime] = {}
         self.__codecs: Dict[int, RTCRtpCodecParameters] = {}
         self.__decoder_queue: queue.Queue = queue.Queue()
@@ -449,6 +450,10 @@ class RTCRtpReceiver:
         Handle an incoming RTP packet.
         """
         self.__log_debug("< %s", packet)
+
+        # If the receiver is disabled, discard the packet.
+        if not self._enabled:
+            return
 
         # feed bitrate estimator
         if self.__remote_bitrate_estimator is not None:

--- a/src/aiortc/rtcrtptransceiver.py
+++ b/src/aiortc/rtcrtptransceiver.py
@@ -29,6 +29,7 @@ class RTCRtpTransceiver:
         sender: RTCRtpSender,
         direction: str = "sendrecv",
     ):
+        self.__currentDirection: Optional[str] = None
         self.__direction = direction
         self.__kind = kind
         self.__mid: Optional[str] = None
@@ -37,7 +38,6 @@ class RTCRtpTransceiver:
         self.__sender = sender
         self.__stopped = False
 
-        self._currentDirection: Optional[str] = None
         self._offerDirection: Optional[str] = None
         self._preferred_codecs: List[RTCRtpCodecCapability] = []
         self._transport: RTCDtlsTransport = None
@@ -54,7 +54,7 @@ class RTCRtpTransceiver:
 
         One of `'sendrecv'`, `'sendonly'`, `'recvonly'`, `'inactive'` or `None`.
         """
-        return self._currentDirection
+        return self.__currentDirection
 
     @property
     def direction(self) -> str:
@@ -129,6 +129,22 @@ class RTCRtpTransceiver:
         await self.__receiver.stop()
         await self.__sender.stop()
         self.__stopped = True
+
+    def _setCurrentDirection(self, direction: str) -> None:
+        self.__currentDirection = direction
+
+        if direction == "sendrecv":
+            self.__sender._enabled = True
+            self.__receiver._enabled = True
+        elif direction == "sendonly":
+            self.__sender._enabled = True
+            self.__receiver._enabled = False
+        elif direction == "recvonly":
+            self.__sender._enabled = False
+            self.__receiver._enabled = True
+        elif direction == "inactive":
+            self.__sender._enabled = False
+            self.__receiver._enabled = False
 
     def _set_mid(self, mid: str) -> None:
         self.__mid = mid


### PR DESCRIPTION
Fixes #1053 

Enable or disable them based on the negotiated direction.

This avoids RTCRtpSender sending RTP and RTCRtpReceiver processing incoming RTP if disabled.