### PR TITLE
Stop using deprecated `audioop` for G711 and Opus

### DIFF
--- a/src/aiortc/codecs/g711.py
+++ b/src/aiortc/codecs/g711.py
@@ -1,9 +1,9 @@
-import audioop
 import fractions
-from abc import ABC, abstractmethod
-from typing import List, Optional, Tuple
+from typing import List, Tuple
 
-from av import AudioFrame
+from av import AudioFrame, CodecContext
+from av.audio.codeccontext import AudioCodecContext
+from av.audio.resampler import AudioResampler
 from av.frame import Frame
 from av.packet import Packet
 
@@ -17,29 +17,35 @@ SAMPLES_PER_FRAME = 160
 TIME_BASE = fractions.Fraction(1, 8000)
 
 
-class PcmDecoder(ABC, Decoder):
-    @staticmethod
-    @abstractmethod
-    def _convert(data: bytes, width: int) -> bytes:
-        pass  # pragma: no cover
+class PcmDecoder(Decoder):
+    def __init__(self, codec_name: str) -> None:
+        self.codec: AudioCodecContext = CodecContext.create(codec_name, "r")
+        self.codec.format = "s16"
+        self.codec.layout = "mono"
+        self.codec.sample_rate = SAMPLE_RATE
 
     def decode(self, encoded_frame: JitterFrame) -> List[Frame]:
-        frame = AudioFrame(format="s16", layout="mono", samples=SAMPLES_PER_FRAME)
-        frame.planes[0].update(self._convert(encoded_frame.data, SAMPLE_WIDTH))
-        frame.pts = encoded_frame.timestamp
-        frame.sample_rate = SAMPLE_RATE
-        frame.time_base = TIME_BASE
-        return [frame]
+        packet = Packet(encoded_frame.data)
+        packet.pts = encoded_frame.timestamp
+        packet.time_base = TIME_BASE
+        return self.codec.decode(packet)
 
 
-class PcmEncoder(ABC, Encoder):
-    @staticmethod
-    @abstractmethod
-    def _convert(data: bytes, width: int) -> bytes:
-        pass  # pragma: no cover
+class PcmEncoder(Encoder):
+    def __init__(self, codec_name: str) -> None:
+        self.codec: AudioCodecContext = CodecContext.create(codec_name, "w")
+        self.codec.format = "s16"
+        self.codec.layout = "mono"
+        self.codec.sample_rate = SAMPLE_RATE
+        self.codec.time_base = TIME_BASE
 
-    def __init__(self) -> None:
-        self.rate_state: Optional[Tuple[int, Tuple[Tuple[int, int], ...]]] = None
+        # Create our own resampler to control the frame size.
+        self.resampler = AudioResampler(
+            format="s16",
+            layout="mono",
+            rate=SAMPLE_RATE,
+            frame_size=SAMPLES_PER_FRAME,
+        )
 
     def encode(
         self, frame: Frame, force_keyframe: bool = False
@@ -48,28 +54,17 @@ class PcmEncoder(ABC, Encoder):
         assert frame.format.name == "s16"
         assert frame.layout.name in ["mono", "stereo"]
 
-        channels = len(frame.layout.channels)
-        data = bytes(frame.planes[0])
-        timestamp = frame.pts
+        # Send frame through resampler and encoder.
+        packets = []
+        for frame in self.resampler.resample(frame):
+            packets += self.codec.encode(frame)
 
-        # resample at 8 kHz
-        if frame.sample_rate != SAMPLE_RATE:
-            data, self.rate_state = audioop.ratecv(
-                data,
-                SAMPLE_WIDTH,
-                channels,
-                frame.sample_rate,
-                SAMPLE_RATE,
-                self.rate_state,
-            )
-            timestamp = (timestamp * SAMPLE_RATE) // frame.sample_rate
-
-        # convert to mono
-        if channels == 2:
-            data = audioop.tomono(data, SAMPLE_WIDTH, 1, 1)
-
-        data = self._convert(data, SAMPLE_WIDTH)
-        return [data], timestamp
+        if packets:
+            # Packets were returned.
+            return [bytes(p) for p in packets], packets[0].pts
+        else:
+            # No packets were returned due to buffering.
+            return [], None
 
     def pack(self, packet: Packet) -> Tuple[List[bytes], int]:
         timestamp = convert_timebase(packet.pts, packet.time_base, TIME_BASE)
@@ -77,24 +72,20 @@ class PcmEncoder(ABC, Encoder):
 
 
 class PcmaDecoder(PcmDecoder):
-    @staticmethod
-    def _convert(data: bytes, width: int) -> bytes:
-        return audioop.alaw2lin(data, width)
+    def __init__(self) -> None:
+        super().__init__("pcm_alaw")
 
 
 class PcmaEncoder(PcmEncoder):
-    @staticmethod
-    def _convert(data: bytes, width: int) -> bytes:
-        return audioop.lin2alaw(data, width)
+    def __init__(self) -> None:
+        super().__init__("pcm_alaw")
 
 
 class PcmuDecoder(PcmDecoder):
-    @staticmethod
-    def _convert(data: bytes, width: int) -> bytes:
-        return audioop.ulaw2lin(data, width)
+    def __init__(self) -> None:
+        super().__init__("pcm_mulaw")
 
 
 class PcmuEncoder(PcmEncoder):
-    @staticmethod
-    def _convert(data: bytes, width: int) -> bytes:
-        return audioop.lin2ulaw(data, width)
+    def __init__(self) -> None:
+        super().__init__("pcm_mulaw")

--- a/tests/codecs.py
+++ b/tests/codecs.py
@@ -73,7 +73,15 @@ class CodecTestCase(TestCase):
             )
         return frames
 
-    def roundtrip_audio(self, codec, output_layout, output_sample_rate, drop=[]):
+    def roundtrip_audio(
+        self,
+        codec,
+        output_layout,
+        output_sample_rate,
+        input_layout="mono",
+        input_sample_rate=8000,
+        drop=[],
+    ):
         """
         Round-trip an AudioFrame through encoder then decoder.
         """
@@ -81,7 +89,7 @@ class CodecTestCase(TestCase):
         decoder = get_decoder(codec)
 
         input_frames = self.create_audio_frames(
-            layout="mono", sample_rate=8000, count=10
+            layout=input_layout, sample_rate=input_sample_rate, count=10
         )
 
         output_sample_count = int(output_sample_rate * AUDIO_PTIME)

--- a/tests/test_g711.py
+++ b/tests/test_g711.py
@@ -57,12 +57,27 @@ class PcmaTest(CodecTestCase):
         encoder = get_encoder(PCMA_CODEC)
         self.assertIsInstance(encoder, PcmaEncoder)
 
-        for frame in self.create_audio_frames(
-            layout="stereo", sample_rate=48000, count=10
-        ):
-            payloads, timestamp = encoder.encode(frame)
-            self.assertEqual(payloads, [PCMA_PAYLOAD])
-            self.assertEqual(timestamp, frame.pts // 6)
+        output = [
+            encoder.encode(frame)
+            for frame in self.create_audio_frames(
+                layout="stereo", sample_rate=48000, count=10
+            )
+        ]
+        self.assertEqual(
+            output,
+            [
+                ([], None),  # No output due to buffering.
+                ([PCMA_PAYLOAD], 0),
+                ([PCMA_PAYLOAD], 160),
+                ([PCMA_PAYLOAD], 320),
+                ([PCMA_PAYLOAD], 480),
+                ([PCMA_PAYLOAD], 640),
+                ([PCMA_PAYLOAD], 800),
+                ([PCMA_PAYLOAD], 960),
+                ([PCMA_PAYLOAD], 1120),
+                ([PCMA_PAYLOAD], 1280),
+            ],
+        )
 
     def test_encoder_pack(self):
         encoder = get_encoder(PCMA_CODEC)
@@ -124,12 +139,27 @@ class PcmuTest(CodecTestCase):
         encoder = get_encoder(PCMU_CODEC)
         self.assertIsInstance(encoder, PcmuEncoder)
 
-        for frame in self.create_audio_frames(
-            layout="stereo", sample_rate=48000, count=10
-        ):
-            payloads, timestamp = encoder.encode(frame)
-            self.assertEqual(payloads, [PCMU_PAYLOAD])
-            self.assertEqual(timestamp, frame.pts // 6)
+        output = [
+            encoder.encode(frame)
+            for frame in self.create_audio_frames(
+                layout="stereo", sample_rate=48000, count=10
+            )
+        ]
+        self.assertEqual(
+            output,
+            [
+                ([], None),  # No output due to buffering
+                ([PCMU_PAYLOAD], 0),
+                ([PCMU_PAYLOAD], 160),
+                ([PCMU_PAYLOAD], 320),
+                ([PCMU_PAYLOAD], 480),
+                ([PCMU_PAYLOAD], 640),
+                ([PCMU_PAYLOAD], 800),
+                ([PCMU_PAYLOAD], 960),
+                ([PCMU_PAYLOAD], 1120),
+                ([PCMU_PAYLOAD], 1280),
+            ],
+        )
 
     def test_roundtrip(self):
         self.roundtrip_audio(PCMU_CODEC, output_layout="mono", output_sample_rate=8000)

--- a/tests/test_opus.py
+++ b/tests/test_opus.py
@@ -32,31 +32,39 @@ class OpusTest(CodecTestCase):
         encoder = get_encoder(OPUS_CODEC)
         self.assertIsInstance(encoder, OpusEncoder)
 
-        frames = self.create_audio_frames(layout="mono", sample_rate=8000, count=2)
-
-        # first frame
-        payloads, timestamp = encoder.encode(frames[0])
-        self.assertEqual(payloads, [OPUS_PAYLOAD])
-        self.assertEqual(timestamp, 0)
-
-        # second frame
-        payloads, timestamp = encoder.encode(frames[1])
-        self.assertEqual(timestamp, 960)
+        output = [
+            encoder.encode(frame)
+            for frame in self.create_audio_frames(
+                layout="mono", sample_rate=8000, count=3
+            )
+        ]
+        self.assertEqual(
+            output,
+            [
+                ([], None),  # No output due to buffering.
+                ([OPUS_PAYLOAD], 0),
+                ([OPUS_PAYLOAD], 960),
+            ],
+        )
 
     def test_encoder_stereo_8khz(self):
         encoder = get_encoder(OPUS_CODEC)
         self.assertIsInstance(encoder, OpusEncoder)
 
-        frames = self.create_audio_frames(layout="stereo", sample_rate=8000, count=2)
-
-        # first frame
-        payloads, timestamp = encoder.encode(frames[0])
-        self.assertEqual(payloads, [OPUS_PAYLOAD])
-        self.assertEqual(timestamp, 0)
-
-        # second frame
-        payloads, timestamp = encoder.encode(frames[1])
-        self.assertEqual(timestamp, 960)
+        output = [
+            encoder.encode(frame)
+            for frame in self.create_audio_frames(
+                layout="stereo", sample_rate=8000, count=3
+            )
+        ]
+        self.assertEqual(
+            output,
+            [
+                ([], None),  # No output due to buffering.
+                ([OPUS_PAYLOAD], 0),
+                ([OPUS_PAYLOAD], 960),
+            ],
+        )
 
     def test_encoder_stereo_48khz(self):
         encoder = get_encoder(OPUS_CODEC)
@@ -84,10 +92,19 @@ class OpusTest(CodecTestCase):
 
     def test_roundtrip(self):
         self.roundtrip_audio(
-            OPUS_CODEC, output_layout="stereo", output_sample_rate=48000
+            OPUS_CODEC,
+            input_layout="stereo",
+            input_sample_rate=48000,
+            output_layout="stereo",
+            output_sample_rate=48000,
         )
 
     def test_roundtrip_with_loss(self):
         self.roundtrip_audio(
-            OPUS_CODEC, output_layout="stereo", output_sample_rate=48000, drop=[1]
+            OPUS_CODEC,
+            input_layout="stereo",
+            input_sample_rate=48000,
+            output_layout="stereo",
+            output_sample_rate=48000,
+            drop=[1],
         )


### PR DESCRIPTION
The `audioop` module is deprecated and will be removed in Python 3.13, so use PyAV's codecs instead.