### PR TITLE
Fix runners for building macOs wheels

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -97,9 +97,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: macos-latest
+          - os: macos-14
             arch: arm64
-          - os: macos-latest
+          - os: macos-13
             arch: x86_64
           - os: ubuntu-latest
             arch: aarch64


### PR DESCRIPTION
We can not longer use `macos-latest` for both arm64 and x86_64:

- For arm64 use macos-14.
- For x86_64 use macos-13.