### PR TITLE
Fix a typo in `filexfer` example (fixes: #1083)

### DIFF
--- a/examples/datachannel-filexfer/filexfer.py
+++ b/examples/datachannel-filexfer/filexfer.py
@@ -31,7 +31,7 @@ async def consume_signaling(pc, signaling):
             break
 
 
-async def run_answer(pc, signaling, filename):
+async def run_answer(pc, signaling, fp):
     await signaling.connect()
 
     @pc.on("datachannel")


### PR DESCRIPTION
The example "worked" due to a global variable, but this was not the desired code.

Thanks to @angererc for spotting this!