### PR TITLE
Change RTCP Sender to use asyncio.Event() instead of a task cancelled…

### DIFF
--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -90,6 +90,7 @@ class RTCRtpSender:
         self.__rtp_history: Dict[int, RtpPacket] = {}
         self.__rtcp_exited = asyncio.Event()
         self.__rtcp_started = asyncio.Event()
+        self.__rtcp_quitting = asyncio.Event()
         self.__rtcp_task: Optional[asyncio.Future[None]] = None
         self.__rtx_payload_type: Optional[int] = None
         self.__rtx_sequence_number = random16()
@@ -217,6 +218,7 @@ class RTCRtpSender:
             await asyncio.gather(self.__rtp_started.wait(), self.__rtcp_started.wait())
             self.__rtp_task.cancel()
             self.__rtcp_task.cancel()
+            self.__rtcp_quitting.set()
             await asyncio.gather(self.__rtp_exited.wait(), self.__rtcp_exited.wait())
 
     async def _handle_rtcp_packet(self, packet):
@@ -404,7 +406,7 @@ class RTCRtpSender:
         self.__rtcp_started.set()
 
         try:
-            while True:
+            while self.__rtcp_quitting.is_set() == False:
                 # The interval between RTCP packets is varied randomly over the
                 # range [0.5, 1.5] times the calculated interval.
                 await asyncio.sleep(0.5 + random.random())


### PR DESCRIPTION
… exception as that is unreliable after hours of usage, original task.cancel() kept as it is still needed to close it, new while just makes sure it can close.

I've been creating an NVR software based around Flask and AioRTC, I have observed through rigorous testing that after extensive time alive (5+ hours) rtcp_run does not get the task.cancel() signal, and so the loop continues forever never stopping, meaning I cannot pc.close() after long sessions. 
(Which will happen with an NVR system).

This pull request implements a fix for this by replacing the Cancel signal with an asyncio.Event() object that I have observed reliably delivering a signal and allowing rtcp_run to die. rtc_run has no issues and quits the second the peer closes the tab.

You can find the relevant thread here:
https://github.com/aiortc/aiortc/issues/792

(I'm currently testing this fix for the final time with all my other session quitting issues fixed, so I'll have an answer tomorrow morning.)

My project for reference (Relevant code not present, have not committed yet.):
https://github.com/R0NAM1/zemond