### PR TITLE
Allow using PyAV 12.x

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -27,7 +27,7 @@ classifiers = [
 ]
 dependencies = [
     "aioice>=0.9.0,<1.0.0",
-    "av>=9.0.0,<12.0.0",
+    "av>=9.0.0,<13.0.0",
     "cffi>=1.0.0",
     "cryptography>=42.0.0",
     'dataclasses; python_version < "3.7"',


### PR DESCRIPTION
The API remains compatible, so allow more recent versions of PyAV.