### PR TITLE
Set correct codec for ogg output

### DIFF
--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -433,6 +433,8 @@ class MediaRecorder:
                 codec_name = "pcm_s16le"
             elif self.__container.format.name == "mp3":
                 codec_name = "mp3"
+            elif self.__container.format.name == "ogg":
+                codec_name = "libopus"
             else:
                 codec_name = "aac"
             stream = self.__container.add_stream(codec_name)

--- a/tests/test_contrib_media.py
+++ b/tests/test_contrib_media.py
@@ -606,39 +606,34 @@ class MediaPlayerNoDecodeTest(MediaPlayerTest):
 
 
 class MediaRecorderTest(MediaTestCase):
-    @asynctest
-    async def test_audio_mp3(self):
-        path = self.temporary_path("test.mp3")
+    async def check_audio_recording(self, filename, codec_names):
+        # Record audio.
+        path = self.temporary_path(filename)
         recorder = MediaRecorder(path)
         recorder.addTrack(AudioStreamTrack())
         await recorder.start()
         await asyncio.sleep(2)
         await recorder.stop()
 
-        # check output media
+        # Check audio recording.
         container = av.open(path, "r")
         self.assertEqual(len(container.streams), 1)
-        self.assertIn(container.streams[0].codec.name, ("mp3", "mp3float"))
+        self.assertIn(container.streams[0].codec.name, codec_names)
         self.assertGreater(
             float(container.streams[0].duration * container.streams[0].time_base), 0
         )
+
+    @asynctest
+    async def test_audio_mp3(self):
+        await self.check_audio_recording("test.mp3", ("mp3", "mp3float"))
+
+    @asynctest
+    async def test_audio_ogg(self):
+        await self.check_audio_recording("test.ogg", ("opus",))
 
     @asynctest
     async def test_audio_wav(self):
-        path = self.temporary_path("test.wav")
-        recorder = MediaRecorder(path)
-        recorder.addTrack(AudioStreamTrack())
-        await recorder.start()
-        await asyncio.sleep(2)
-        await recorder.stop()
-
-        # check output media
-        container = av.open(path, "r")
-        self.assertEqual(len(container.streams), 1)
-        self.assertEqual(container.streams[0].codec.name, "pcm_s16le")
-        self.assertGreater(
-            float(container.streams[0].duration * container.streams[0].time_base), 0
-        )
+        await self.check_audio_recording("test.wav", ("pcm_s16le",))
 
     @asynctest
     async def test_audio_wav_ended(self):


### PR DESCRIPTION
Use `libopus` if the output format as `ogg`. That's a pretty important case as WebRTC audio streams are usually opus streams.