### PR TITLE
Fix reversed mid

### DIFF
--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -843,6 +843,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
                 for t in self.__transceivers:
                     if t.kind == media.kind and t.mid in [None, media.rtp.muxId]:
                         transceiver = t
+                        break
                 if transceiver is None:
                     transceiver = self.__createTransceiver(
                         direction="recvonly", kind=media.kind

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -5142,3 +5142,28 @@ a=rtpmap:0 PCMU/8000
         self.assertEqual(
             pc2_states["connectionState"], ["new", "connecting", "connected", "closed"]
         )
+
+    @asynctest
+    async def test_right_mid_order(self):
+        pc1 = RTCPeerConnection()
+        pc2 = RTCPeerConnection()
+
+        tr1_a = pc1.addTransceiver("video", "recvonly")
+        tr1_b = pc1.addTransceiver("video", "recvonly")
+        offer = await pc1.createOffer()
+        self.assertEqual(offer.type, "offer")
+
+        await pc1.setLocalDescription(offer)
+
+        tr2_a = pc2.addTransceiver(VideoStreamTrack())
+        tr2_b = pc2.addTransceiver(VideoStreamTrack())
+        await pc2.setRemoteDescription(offer)
+
+        self.assertEqual(tr1_a.mid, tr2_a.mid)
+        self.assertEqual(tr1_b.mid, tr2_b.mid)
+
+        # close
+        await pc1.close()
+        await pc2.close()
+        self.assertClosed(pc1)
+        self.assertClosed(pc2)


### PR DESCRIPTION
If no break statement in the changed file, the last unmatched transceiver will get. That will cause mid order different from addtrack() order in the multiple video track situation which is counterintuitive. This commit fixes it by breaking the loop in advance.