### PR TITLE
Update vpx.py - issue fixed TypeError: cannot convert 'NoneType' object to bytes

### DIFF
--- a/src/aiortc/codecs/vpx.py
+++ b/src/aiortc/codecs/vpx.py
@@ -355,8 +355,12 @@ class Vp8Encoder(Encoder):
         return payloads, timestamp
 
     def pack(self, packet: Packet) -> Tuple[List[bytes], int]:
-        payloads = self._packetize(bytes(packet), self.picture_id)
-        timestamp = convert_timebase(packet.pts, packet.time_base, VIDEO_TIME_BASE)
+        if packet is None:
+            payloads = self._packetize(bytes(), self.picture_id)
+            timestamp = convert_timebase(0, 0, VIDEO_TIME_BASE)
+        else:        
+            payloads = self._packetize(bytes(packet), self.picture_id)
+            timestamp = convert_timebase(packet.pts, packet.time_base, VIDEO_TIME_BASE)
         self.picture_id = (self.picture_id + 1) % (1 << 15)
         return payloads, timestamp
 


### PR DESCRIPTION

Solved an issue where the connection was interrupted due to an error when the package came in at none.

An issue that occurs intermittently when a viewer using aiortc library is created with python code
error log with aiortc 1.8.0 and 1.9.0
```
ERROR:root:Error receiving video frame: float division by zero
<class 'NoneType'>
WARNING:aiortc.rtcrtpsender:RTCRtpsender(<class '__main__.SimpleVideoTrack'>) Traceback (most recent call last):
  File "C:\Users\jinseon\AppData\Local\Programs\Python\Python311\Lib\site-packages\aiortc\rtcrtpsender.py", line 346, in _run_rtp
    enc_frame = await self._next_encoded_frame(codec)
                ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\jinseon\AppData\Local\Programs\Python\Python311\Lib\site-packages\aiortc\rtcrtpsender.py", line 298, in _next_encoded_frame
    payloads, timestamp = self.__encoder.pack(data)
                          ^^^^^^^^^^^^^^^^^^^^^^^^^
  File "C:\Users\jinseon\AppData\Local\Programs\Python\Python311\Lib\site-packages\aiortc\codecs\vpx.py", line 359, in pack
    payloads = self._packetize(bytes(packet), self.picture_id)
                               ^^^^^^^^^^^^^
TypeError: cannot convert 'NoneType' object to bytes

WARNING:aiortc.rtcdtlstransport:RTCDtlsTransport(server) Traceback (most recent call last):
  File "C:\Users\jinseon\AppData\Local\Programs\Python\Python311\Lib\site-packages\aiortc\rtcdtlstransport.py", line 517, in __run
    await self._recv_next()
  File "C:\Users\jinseon\AppData\Local\Programs\Python\Python311\Lib\site-packages\aiortc\rtcdtlstransport.py", line 614, in _recv_next
    await self._handle_rtcp_data(data)
  File "C:\Users\jinseon\AppData\Local\Programs\Python\Python311\Lib\site-packages\aiortc\rtcdtlstransport.py", line 557, in _handle_rtcp_data
    await recipient._handle_rtcp_packet(packet)
  File "C:\Users\jinseon\AppData\Local\Programs\Python\Python311\Lib\site-packages\aiortc\rtcrtpsender.py", line 264, in _handle_rtcp_packet
    if self.__encoder and hasattr(self.__encoder, "target_bitrate"):
       ^^^^^^^^^^^^^^
AttributeError: 'RTCRtpSender' object has no attribute '_RTCRtpSender__encoder'

```

I have checked that the error does not occur when adding a None type check to 'vpx.py'.
codecs/vpx.py
```
    def pack(self, packet: Packet) -> Tuple[List[bytes], int]:
        if packet is None:
            payloads = self._packetize(bytes(), self.picture_id)
            timestamp = convert_timebase(0, 0, VIDEO_TIME_BASE)
        else:
            payloads = self._packetize(bytes(packet), self.picture_id)
            timestamp = convert_timebase(packet.pts, packet.time_base, VIDEO_TIME_BASE)
        self.picture_id = (self.picture_id + 1) % (1 << 15)
        return payloads, timestamp
```


