### PR TITLE
Remux example

### DIFF
--- a/examples/remux/README.rst
+++ b/examples/remux/README.rst
@@ -1,0 +1,56 @@
+Remux server 
+=============
+
+This example illustrates how to remux a video stream that is originally not packed in MPEGTS container so that it can be streamed without transcoding. An example usecase is playing the video content from an RTSP source that sends raw H265 streams.
+
+
+Running
+-------
+
+First install the required packages:
+
+.. code-block:: console
+
+    $ pip install aiohttp aiortc
+
+When you start the example, it will create an HTTP server which you can connect to from your browser. You should pass video source address through the "--play-from" and specify the source encoding, for example:
+
+.. code-block:: console
+
+    $ python server.py --play-from=rtsp://localhost:8554/webcam --video-codec="video/H264"
+
+You can then browse to the following page with your browser:
+
+http://127.0.0.1:8080
+
+Once you click `Start` the server will send video from its webcam to the
+browser.
+
+.. warning:: Due to the timing of when Firefox starts responding to mDNS
+ requests and the current lack of ICE trickle support in aiortc, this example
+ may not work with Firefox. For details see:
+
+ https://github.com/aiortc/aiortc/issues/481 and
+ https://bugzilla.mozilla.org/show_bug.cgi?id=1691189
+
+Webcam over RTSP
+----------------
+
+You can generate an RTSP stream from webcam by following these steps:
+
+1. Run a local RTSP proxy server such as [mediamtx](https://github.com/bluenviron/mediamtx)
+
+2. Capture video from webcam and stream it over RTSP. If you are an MacOS user and use mediamtx as RTSP proxy server, you can try this command. This will generate H264 encoded webcam video stream and send it to "localhost:8554" with stream name "webcam".
+
+.. code-block:: console
+
+    $ ffmpeg \
+      -f avfoundation \
+      -pix_fmt yuyv422 \
+      -video_size 640x480 \
+      -framerate 30 \
+      -i "0:0" \
+      -c:v h264_videotoolbox \
+      -maxrate 2000k -bufsize 1000k \
+      -an \
+      -f rtsp -rtsp_transport tcp rtsp://localhost:8554/webcam

--- a/examples/remux/client.js
+++ b/examples/remux/client.js
@@ -1,0 +1,73 @@
+var pc = null;
+
+function negotiate() {
+    pc.addTransceiver('video', {
+        direction: 'recvonly',
+    });
+    return pc.createOffer().then((offer) => {
+        return pc.setLocalDescription(offer);
+    }).then(() => {
+        // wait for ICE gathering to complete
+        return new Promise((resolve) => {
+            if (pc.iceGatheringState === 'complete') {
+                resolve();
+            } else {
+                const checkState = () => {
+                    if (pc.iceGatheringState === 'complete') {
+                        pc.removeEventListener('icegatheringstatechange', checkState);
+                        resolve();
+                    }
+                };
+                pc.addEventListener('icegatheringstatechange', checkState);
+            }
+        });
+    }).then(() => {
+        var offer = pc.localDescription;
+        return fetch('/offer', {
+            body: JSON.stringify({
+                sdp: offer.sdp,
+                type: offer.type,
+            }),
+            headers: {
+                'Content-Type': 'application/json'
+            },
+            method: 'POST'
+        });
+    }).then((response) => {
+        return response.json();
+    }).then((answer) => {
+        return pc.setRemoteDescription(answer);
+    }).catch((e) => {
+        alert(e);
+    });
+}
+
+function start() {
+    var config = {
+        sdpSemantics: 'unified-plan'
+    };
+
+    pc = new RTCPeerConnection(config);
+
+    // connect audio / video
+    pc.addEventListener('track', (evt) => {
+        if (evt.track.kind == 'video') {
+            document.getElementById('video').srcObject = evt.streams[0];
+        } else {
+            document.getElementById('audio').srcObject = evt.streams[0];
+        }
+    });
+
+    document.getElementById('start').style.display = 'none';
+    negotiate();
+    document.getElementById('stop').style.display = 'inline-block';
+}
+
+function stop() {
+    document.getElementById('stop').style.display = 'none';
+
+    // close peer connection
+    setTimeout(() => {
+        pc.close();
+    }, 500);
+}

--- a/examples/remux/index.html
+++ b/examples/remux/index.html
@@ -1,0 +1,36 @@
+<!DOCTYPE html>
+<html>
+<head>
+    <meta charset="UTF-8"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>WebRTC webcam</title>
+    <style>
+    button {
+        padding: 8px 16px;
+    }
+
+    video {
+        width: 100%;
+    }
+
+    .option {
+        margin-bottom: 8px;
+    }
+
+    #media {
+        max-width: 1280px;
+    }
+    </style>
+</head>
+<body>
+<button id="start" onclick="start()">Start</button>
+<button id="stop" style="display: none" onclick="stop()">Stop</button>
+
+<div id="media">
+    <h2>Media</h2>
+    <video id="video" autoplay="true" playsinline="true"></video>
+</div>
+
+<script src="client.js"></script>
+</body>
+</html>

--- a/examples/remux/server.py
+++ b/examples/remux/server.py
@@ -1,0 +1,178 @@
+import argparse
+import asyncio
+import json
+import logging
+import os
+import subprocess
+import av
+import threading
+from multiprocessing import Event
+from aiohttp import web
+from aiortc.mediastreams import MediaStreamError
+from aiortc import (
+    RTCConfiguration,
+    RTCPeerConnection,
+    RTCSessionDescription,
+    MediaStreamTrack,
+)
+from aiortc.rtcrtpsender import RTCRtpSender
+import av.packet
+
+ROOT = os.path.dirname(__file__)
+
+track = None
+worker_thread = None
+term_event = Event()
+
+
+class PacketStreamTrack(MediaStreamTrack):
+
+    kind = "video"
+
+    def __init__(self):
+        super().__init__()
+        self.queue = asyncio.Queue(maxsize=30)
+
+    async def recv(self):
+        packet = await self.queue.get()
+        if packet is None:
+            self.stop()
+            raise MediaStreamError
+        return packet
+
+
+def run_remux_worker_ffmpeg(source, track, loop):
+    process = subprocess.Popen(
+        [
+            "ffmpeg",
+            "-i",
+            source,
+            "-c",
+            "copy",  # Copy codecs without re-encoding
+            "-f",
+            "mpegts",
+            "-",
+        ],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.DEVNULL,
+        bufsize=1000,
+    )
+
+    container = av.open(process.stdout, format="mpegts", mode="r", buffer_size=1000)
+    for packet in container.demux(video=0):
+        print(packet)
+        if packet.dts is not None:
+            asyncio.run_coroutine_threadsafe(track.queue.put(packet), loop)
+
+        if term_event.is_set():
+            break
+
+    process.terminate()
+    container.close()
+    asyncio.run_coroutine_threadsafe(track.queue.put(None), loop)
+
+
+def create_remux_tracks(source: str):
+    global track, worker_thread
+
+    if not worker_thread:
+        track = PacketStreamTrack()
+        worker_thread = threading.Thread(
+            target=run_remux_worker_ffmpeg,
+            args=(source, track, asyncio.get_event_loop()),
+        )
+        worker_thread.start()
+
+    return track
+
+
+def force_codec(pc, sender, forced_codec):
+    kind = forced_codec.split("/")[0]
+    codecs = RTCRtpSender.getCapabilities(kind).codecs
+    transceiver = next(t for t in pc.getTransceivers() if t.sender == sender)
+    transceiver.setCodecPreferences(
+        [codec for codec in codecs if codec.mimeType == forced_codec]
+    )
+
+
+async def index(request):
+    content = open(os.path.join(ROOT, "index.html"), "r").read()
+    return web.Response(content_type="text/html", text=content)
+
+
+async def javascript(request):
+    content = open(os.path.join(ROOT, "client.js"), "r").read()
+    return web.Response(content_type="application/javascript", text=content)
+
+
+async def offer(request):
+    params = await request.json()
+    offer = RTCSessionDescription(sdp=params["sdp"], type=params["type"])
+
+    pc = RTCPeerConnection(RTCConfiguration(iceServers=[]))
+    pcs.add(pc)
+
+    @pc.on("connectionstatechange")
+    async def on_connectionstatechange():
+        print("Connection state is %s" % pc.connectionState)
+        if pc.connectionState == "failed":
+            await pc.close()
+            pcs.discard(pc)
+
+    track = create_remux_tracks(args.play_from)
+    video_sender = pc.addTrack(track)
+    force_codec(pc, video_sender, args.video_codec)
+    await pc.setRemoteDescription(offer)
+
+    answer = await pc.createAnswer()
+    await pc.setLocalDescription(answer)
+
+    return web.Response(
+        content_type="application/json",
+        text=json.dumps(
+            {"sdp": pc.localDescription.sdp, "type": pc.localDescription.type}
+        ),
+    )
+
+
+pcs = set()
+
+
+async def on_shutdown(app):
+    term_event.set()
+
+    # close peer connections
+    coros = [pc.close() for pc in pcs]
+    await asyncio.gather(*coros)
+    pcs.clear()
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="WebRTC webcam demo")
+    parser.add_argument(
+        "--play-from",
+        help="The media source, be a live stream transport address (e.g., RTSP url)",
+    )
+    parser.add_argument(
+        "--video-codec", help="Force a specific video codec (e.g. video/H264)"
+    )
+    parser.add_argument(
+        "--host", default="0.0.0.0", help="Host for HTTP server (default: 0.0.0.0)"
+    )
+    parser.add_argument(
+        "--port", type=int, default=8080, help="Port for HTTP server (default: 8080)"
+    )
+    parser.add_argument("--verbose", "-v", action="count")
+    args = parser.parse_args()
+
+    if args.verbose:
+        logging.basicConfig(level=logging.DEBUG)
+    else:
+        logging.basicConfig(level=logging.INFO)
+
+    app = web.Application()
+    app.on_shutdown.append(on_shutdown)
+    app.router.add_get("/", index)
+    app.router.add_get("/client.js", javascript)
+    app.router.add_post("/offer", offer)
+    web.run_app(app, host=args.host, port=args.port)


### PR DESCRIPTION
Hii 👋

Here I added a simple example to illustrate how to remux a live media source (e.g., from RTSP) to use MPEGTS container, so that aiortc can stream it without transcoding.

In the example, I ran the remuxing in a child process executing plain ffmpeg command. I feel like it isn't the most ideal solution as it does assume the user has an existing ffmpeg. I tried [pyav's remuxing example](https://pyav.org/docs/develop/cookbook/basics.html#remuxing), but couldn't figure out how to properly create an output MPEGTS container that writes to some bytes buffer which then can be read and  parsed to generate pyav Packets...