### PR TITLE
Add support for Python 3.13

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -10,7 +10,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install OS packages
         run: |
           sudo apt-get update
@@ -26,7 +26,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install packages
         run: pip install check-manifest mypy ruff
       - name: Run linters
@@ -42,11 +42,11 @@ jobs:
       matrix:
         os: [ubuntu-latest]
         python:
+          - '3.13'
           - '3.12'
           - '3.11'
           - '3.10'
           - '3.9'
-          - '3.8'
     steps:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
@@ -81,7 +81,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Build source package
         run: |
           pip install -U build
@@ -116,7 +116,7 @@ jobs:
       - uses: actions/checkout@v4
       - uses: actions/setup-python@v5
         with:
-          python-version: 3.8
+          python-version: 3.9
       - name: Install QEMU
         if: matrix.os == 'ubuntu-latest'
         uses: docker/setup-qemu-action@v3

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,7 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "aiortc"
 description = "An implementation of WebRTC and ORTC"
 readme = "README.rst"
-requires-python = ">=3.8"
+requires-python = ">=3.9"
 license = { text = "BSD-3-Clause" }
 authors = [
     { name = "Jeremy Lainé", email = "jeremy.laine@m4x.org" },
@@ -19,18 +19,17 @@ classifiers = [
     "Operating System :: OS Independent",
     "Programming Language :: Python",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: 3.12",
+    "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
     "aioice>=0.9.0,<1.0.0",
     "av>=9.0.0,<14.0.0",
     "cffi>=1.0.0",
     "cryptography>=42.0.0",
-    'dataclasses; python_version < "3.7"',
     "google-crc32c>=1.1",
     "pyee>=9.0.0",
     "pylibsrtp>=0.10.0",

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ class bdist_wheel_abi3(bdist_wheel):
         python, abi, plat = super().get_tag()
 
         if python.startswith("cp"):
-            return "cp38", "abi3", plat
+            return "cp39", "abi3", plat
 
         return python, abi, plat
 

--- a/src/aiortc/contrib/signaling.py
+++ b/src/aiortc/contrib/signaling.py
@@ -167,7 +167,10 @@ class UnixSocketSignaling:
         if self._server is not None:
             self._server.close()
             self._server = None
-            os.unlink(self._path)
+            # In Python 3.13, asyncio Unix sockets are removed when the server is
+            # closed. On previous version we need to remove the socket ourselves.
+            if sys.version_info < (3, 13):
+                os.unlink(self._path)
 
     async def receive(self):
         await self._connect(False)


### PR DESCRIPTION
Adds support for Python 3.13 and drops support for EOL Python 3.8.

Feel free to edit or close if someone else is already working on this. I know this was unsolicited, but I was testing aiortc in Python 3.13 anyways and figured I'd share the changes.

There were two substantive changes:
1. Increase the upper limit for PyAV to support v13. This did cause an assertion in one test case to fail (`test_encoder_large`), but as far as I can tell there is no reason that the length of the payloads in that test must be one (nothing in the git blame indicated that either).
2. In Python 3.13, asyncio Unix sockets are removed when the server is closed so the explicit unlink needs to be skipped.
