### PR TITLE
NVIDIA Hardware Acceleration for H264 encoder

### DIFF
--- a/src/aiortc/__init__.py
+++ b/src/aiortc/__init__.py
@@ -47,7 +47,7 @@ from .stats import (
     RTCTransportStats,
 )
 
-__version__ = "1.9.0"
+__version__ = "1.9.1"
 
 # Disable PyAV's logging framework as it can lead to thread deadlocks.
 av.logging.restore_default_callback()

--- a/src/aiortc/codecs/h264.py
+++ b/src/aiortc/codecs/h264.py
@@ -133,7 +133,7 @@ def create_encoder_context(
     codec.options = {
         "profile": "baseline",
         "level": "31",
-        "tune": "zerolatency",  # does nothing using h264_omx
+        "tune": "zerolatency" if codec_name != "h264_nvenc" else "ull",  # does nothing using h264_omx
     }
     codec.open()
     return codec, codec_name == "h264_omx"
@@ -289,6 +289,13 @@ class H264Encoder(Encoder):
             try:
                 self.codec, self.codec_buffering = create_encoder_context(
                     "h264_omx", frame.width, frame.height, bitrate=self.target_bitrate
+                )
+            except Exception:
+                pass
+            
+            try:
+                self.codec, self.codec_buffering = create_encoder_context(
+                    "h264_nvenc", frame.width, frame.height, bitrate=self.target_bitrate
                 )
             except Exception:
                 self.codec, self.codec_buffering = create_encoder_context(


### PR DESCRIPTION
This pull request adds the ability for an H264 Encoder to use the `h264_nvenc` Hardware Acceleration encoder. The `h264_nvenc` check is similar to the `h264_omx` check in the `H264Encoder._encode_frame` function. Additionally, this request changes the logic in the `create_encoder_context` function to prevent the `h264_nvenc` from receiving "zerolatency" tuning, which is incompatible. One caveat is that this pull request requires PyAV with system-installed FFmpeg, e.g. `pip install av --no-binary av`.