### PR TITLE
Stop transceiver when remote media direction is inactive

### DIFF
--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -475,7 +475,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
             direction=direction, kind=kind, sender_track=track
         )
 
-    async def close(self):
+    async def close(self) -> None:
         """
         Terminate the ICE agent, ending ICE processing and streams.
         """


### PR DESCRIPTION
I have issue when trying to connect AioRTC client with Golang Pion based SFU that I made and I struggled to detect if remote track is stopped sending a media stream because even the remote track is stop and the remote peer which is Pion based SFU is negotiating by send an SDP with inactive direction in media SDP line, the AioRTC peer is doing nothing about it and never trigger track ended event.

I saw similar issues like [this](https://github.com/aiortc/aiortc/issues/1137), and [this](https://github.com/aiortc/aiortc/issues/1129) in AioRTC but no solutions so far.

I follow the implementation of Pion [RTCPeerConnection.SetRemoteDescription()](https://github.com/pion/webrtc/blob/1ee02999eb6ce157c291fc2dbf0d43bf5c700c71/peerconnection.go#L1090) which will check if a remote media has inactive direction and stop the related local transceiver which will trigger the track ended event.