### PR TITLE
Add support for sha-384 and sha-512 certificate fingerprints

### DIFF
--- a/tests/test_rtcdtlstransport.py
+++ b/tests/test_rtcdtlstransport.py
@@ -80,9 +80,13 @@ class RTCCertificateTest(TestCase):
         self.assertIsInstance(expires, datetime.datetime)
 
         fingerprints = certificate.getFingerprints()
-        self.assertEqual(len(fingerprints), 1)
+        self.assertEqual(len(fingerprints), 3)
         self.assertEqual(fingerprints[0].algorithm, "sha-256")
         self.assertEqual(len(fingerprints[0].value), 95)
+        self.assertEqual(fingerprints[1].algorithm, "sha-384")
+        self.assertEqual(len(fingerprints[1].value), 143)
+        self.assertEqual(fingerprints[2].algorithm, "sha-512")
+        self.assertEqual(len(fingerprints[2].value), 191)
 
 
 class RTCDtlsTransportTest(TestCase):


### PR DESCRIPTION
We now support SHA-256, SHA-384 and SHA-512 certificate fingerprints:

- We generate fingerprints for all supported algorithms.
- When checking fingerprints, we verify there is at least one supported algorithm, and that all supported fingerprints match.