### PR TITLE
implement bundlePolicy

### DIFF
--- a/docs/api.rst
+++ b/docs/api.rst
@@ -12,6 +12,9 @@ WebRTC
    .. autoclass:: RTCSessionDescription
       :members:
 
+   .. autoclass:: RTCBundlePolicy()
+      :members:
+
    .. autoclass:: RTCConfiguration
       :members:
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "aioice>=0.9.0,<1.0.0",
+    "aioice>=0.10.1,<1.0.0",
     "av>=14.0.0,<15.0.0",
     "cffi>=1.0.0",
     "cryptography>=44.0.0",

--- a/src/aiortc/__init__.py
+++ b/src/aiortc/__init__.py
@@ -8,7 +8,7 @@ from .mediastreams import (
     MediaStreamTrack,
     VideoStreamTrack,
 )
-from .rtcconfiguration import RTCConfiguration, RTCIceServer
+from .rtcconfiguration import RTCBundlePolicy, RTCConfiguration, RTCIceServer
 from .rtcdatachannel import RTCDataChannel, RTCDataChannelParameters
 from .rtcdtlstransport import (
     RTCCertificate,
@@ -61,6 +61,7 @@ __all__ = [
     "InvalidStateError",
     "MediaStreamError",
     "MediaStreamTrack",
+    "RTCBundlePolicy",
     "RTCCertificate",
     "RTCConfiguration",
     "RTCDataChannel",

--- a/src/aiortc/rtcconfiguration.py
+++ b/src/aiortc/rtcconfiguration.py
@@ -1,3 +1,4 @@
+import enum
 from dataclasses import dataclass
 from typing import Optional, Union
 
@@ -22,6 +23,35 @@ class RTCIceServer:
     credentialType: str = "password"
 
 
+class RTCBundlePolicy(enum.Enum):
+    """
+    The :class:`RTCBundlePolicy` affects which media tracks are negotiated if
+    the remote endpoint is not bundle-aware, and what ICE candidates are
+    gathered.
+
+    See https://w3c.github.io/webrtc-pc/#rtcbundlepolicy-enum
+    """
+
+    BALANCED = "balanced"
+    """
+    Gather ICE candidates for each media type in use (audio, video, and data).
+    If the remote endpoint is not bundle-aware, negotiate only one audio and
+    video track on separate transports.
+    """
+
+    MAX_COMPAT = "max-compat"
+    """
+    Gather ICE candidates for each track. If the remote endpoint is not
+    bundle-aware, negotiate all media tracks on separate transports.
+    """
+
+    MAX_BUNDLE = "max-bundle"
+    """
+    Gather ICE candidates for only one track. If the remote endpoint is not
+    bundle-aware, negotiate only one media track.
+    """
+
+
 @dataclass
 class RTCConfiguration:
     """
@@ -31,3 +61,6 @@ class RTCConfiguration:
 
     iceServers: Optional[list[RTCIceServer]] = None
     "A list of :class:`RTCIceServer` objects to configure STUN / TURN servers."
+
+    bundlePolicy: RTCBundlePolicy = RTCBundlePolicy.BALANCED
+    "The media-bundling policy to use when gathering ICE candidates."

--- a/src/aiortc/rtcicetransport.py
+++ b/src/aiortc/rtcicetransport.py
@@ -174,7 +174,12 @@ class RTCIceGatherer(AsyncIOEventEmitter):
     exchanged in signaling.
     """
 
-    def __init__(self, iceServers: Optional[list[RTCIceServer]] = None) -> None:
+    def __init__(
+        self,
+        iceServers: Optional[list[RTCIceServer]] = None,
+        local_username: Optional[str] = None,
+        local_password: Optional[str] = None,
+    ) -> None:
         super().__init__()
 
         if iceServers is None:

--- a/src/aiortc/rtcrtptransceiver.py
+++ b/src/aiortc/rtcrtptransceiver.py
@@ -130,6 +130,13 @@ class RTCRtpTransceiver:
         await self.__sender.stop()
         self.__stopped = True
 
+    @property
+    def transport(self) -> RTCDtlsTransport:
+        """
+        The :class:`RTCDtlsTransport` over which media are transmitted.
+        """
+        return self._transport
+
     def _setCurrentDirection(self, direction: str) -> None:
         self.__currentDirection = direction
 


### PR DESCRIPTION
fixes #555

Notably this also changes the default behavior to share the same ice-ufrag/ice-pwd for all transceivers and the sctp transport, aligning with browsers.