### PR TITLE
Be more cautious when releasing `RTCRtpSender`'s encoder (fixes: #1124)

### DIFF
--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -406,8 +406,7 @@ class RTCRtpSender:
             self.__track = None
 
         # release encoder
-        if self.__encoder:
-            del self.__encoder
+        self.__encoder = None
 
         self.__log_debug("- RTP finished")
         self.__rtp_exited.set()


### PR DESCRIPTION
We used `del` to forcibly drop the reference to the encoder and allow it to be garbage collected. However it also means that the `RTCRtpSender` no longer has an `__encoder` attribute from then on. We can encounter a race condition during shutdown where we receive an RTCP packet, which causes access to the removed `__encoder` attribute.

Instead, just set the `__encoder` attribute back to `None`, as when the `RTCPRtpSender` was constructed.