### PR TITLE
Relax h264 encoder test (fixes: #1166)

### DIFF
--- a/tests/test_h264.py
+++ b/tests/test_h264.py
@@ -114,6 +114,7 @@ class H264Test(CodecTestCase):
         frame = self.create_video_frame(width=640, height=480, pts=0)
         packages, timestamp = encoder.encode(frame)
         self.assertGreaterEqual(len(packages), 1)
+        self.assertEqual(timestamp, 0)
 
     def test_encoder_large(self):
         encoder = get_encoder(H264_CODEC)
@@ -128,7 +129,7 @@ class H264Test(CodecTestCase):
         # delta frame
         frame = self.create_video_frame(width=1280, height=720, pts=3000)
         payloads, timestamp = encoder.encode(frame)
-        self.assertEqual(len(payloads), 1)
+        self.assertGreaterEqual(len(payloads), 1)
         self.assertEqual(timestamp, 3000)
 
         # force keyframe


### PR DESCRIPTION
The exact number of payloads produced on encoding seems to depend on the FFmpeg/libx264 versions, and possibly even the platform.