### PR TITLE
Use `av.FFmpegError` instead of `av.AVError`

### DIFF
--- a/src/aiortc/codecs/h264.py
+++ b/src/aiortc/codecs/h264.py
@@ -113,7 +113,7 @@ class H264Decoder(Decoder):
             packet.pts = encoded_frame.timestamp
             packet.time_base = VIDEO_TIME_BASE
             return cast(List[Frame], self.codec.decode(packet))
-        except av.AVError as e:
+        except av.FFmpegError as e:
             logger.warning(
                 "H264Decoder() failed to decode, skipping package: " + str(e)
             )

--- a/tests/test_contrib_media.py
+++ b/tests/test_contrib_media.py
@@ -360,7 +360,7 @@ class BufferingInputContainer:
         # fail with EAGAIN once
         if not self.__failed:
             self.__failed = True
-            raise av.AVError(errno.EAGAIN, "EAGAIN")
+            raise av.FFmpegError(errno.EAGAIN, "EAGAIN")
 
         return self.__real.decode(*args, **kwargs)
 
@@ -368,7 +368,7 @@ class BufferingInputContainer:
         # fail with EAGAIN once
         if not self.__failed:
             self.__failed = True
-            raise av.AVError(errno.EAGAIN, "EAGAIN")
+            raise av.FFmpegError(errno.EAGAIN, "EAGAIN")
 
         return self.__real.demux(*args, **kwargs)
 


### PR DESCRIPTION
The `AVError` alias to `FFmpegError` is gone in PyAV 14.