### PR TITLE
Add `types-pyOpenSSL` to lint deps

### DIFF
--- a/requirements/lint.txt
+++ b/requirements/lint.txt
@@ -1,3 +1,4 @@
 check-manifest
 mypy
+types-pyOpenSSL
 ruff


### PR DESCRIPTION
Looks like stubs for this packages were not installed. It might be an error in the future.

See https://github.com/python/mypy/pull/18372