### PR TITLE
Fix RTX packet decoding error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,36 @@
+FROM pytorch/pytorch:2.4.0-cuda11.8-cudnn9-runtime
+
+# Install build dependencies
+RUN apt-get update && apt-get install -y \
+    build-essential \
+    wget \
+    pkg-config \
+    python3-dev \
+    yasm
+
+# Build opus from source with PIC
+WORKDIR /build
+RUN wget https://archive.mozilla.org/pub/opus/opus-1.3.1.tar.gz && \
+    tar xvf opus-1.3.1.tar.gz && \
+    cd opus-1.3.1 && \
+    CFLAGS="-fPIC" ./configure --enable-static --disable-shared && \
+    make && \
+    make install
+
+# Build libvpx from source with PIC
+RUN wget https://github.com/webmproject/libvpx/archive/refs/tags/v1.13.0.tar.gz && \
+    tar xvf v1.13.0.tar.gz && \
+    cd libvpx-1.13.0 && \
+    CFLAGS="-fPIC" ./configure --enable-static --disable-shared && \
+    make && \
+    make install
+
+# Install Python dependencies
+RUN pip install wheel setuptools build cffi
+
+# Setup workspace
+WORKDIR /workspace
+COPY . /workspace/
+
+# Update library path
+RUN ldconfig

--- a/README.rst
+++ b/README.rst
@@ -119,6 +119,16 @@ On OS X run:
 
     brew install opus libvpx
 
+Building a wheel without dynamic linking
+....
+
+If you want to build a wheel that does not depend on the system libraries, you
+must first build opus and vpx from source and statically link them. For Linux,
+an example of how to do this would be to build the Dockerfile in this repo,
+uncomment lines in src/_cffi_src/build_[opus/vpx].py to statically link the
+newly built libraries, and then run `python -m build`. You can then copy the
+wheel via `docker cp`.
+
 License
 -------
 

--- a/src/_cffi_src/build_opus.py
+++ b/src/_cffi_src/build_opus.py
@@ -8,6 +8,10 @@ ffibuilder.set_source(
 #include <opus/opus.h>
     """,
     libraries=["opus"],
+    # Comment the above line and uncomment the lines below to static link
+    #libraries=[":libopus.a"],
+    #library_dirs=["/usr/local/lib"],
+    #extra_link_args=["-static-libgcc"]
 )
 
 ffibuilder.cdef(

--- a/src/_cffi_src/build_vpx.py
+++ b/src/_cffi_src/build_vpx.py
@@ -30,6 +30,10 @@ vpx_codec_err_t vpx_codec_enc_init(vpx_codec_ctx_t *ctx,
 }
     """,
     libraries=["vpx"],
+    # Comment the above line and uncomment the lines below to static link
+    #libraries=[":libvpx.a"],
+    #library_dirs=["/usr/local/lib"],
+    #extra_link_args=["-static-libgcc"]
 )
 
 ffibuilder.cdef(

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -506,6 +506,7 @@ class RTCRtpReceiver:
                 return
 
             packet = unwrap_rtx(packet, payload_type=apt, ssrc=original_ssrc)
+            codec = self.__codecs[apt]
 
         # send NACKs for any missing any packets
         if self.__nack_generator is not None and self.__nack_generator.add(packet):


### PR DESCRIPTION
Original problem:
When packets are dropped or lost, RTX packets are sent in WebRTC. In aiortc, these packets, when received by RTCRtpReceiver, errored at runtime citing "ValueError: No decoder found for MIME type `video/rtx`". This happens because after RTX packets are unwrapped, the codec isn't updated to the apt codec, which should be used to decode the unwrapped RTX packet.

This fix updates the codec that will be used to decode the unwrapped RTX packet to the apt codec.