### PR TITLE
Fix the RTCIceServer.urls typing to accept `List[str]` in addition to `str`

### DIFF
--- a/src/aiortc/rtcconfiguration.py
+++ b/src/aiortc/rtcconfiguration.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional
+from typing import List, Optional, Union
 
 
 @dataclass
@@ -10,7 +10,7 @@ class RTCIceServer:
     if any, to connect to the server.
     """
 
-    urls: str
+    urls: Union[str, List[str]]
     """
     This required property is either a single string or a list of strings,
     each specifying a URL which can be used to connect to the server.


### PR DESCRIPTION
`RTCIceServer.urls` can be a `list[str]` as well as `str` like this:
https://github.com/aiortc/aiortc/blob/65cd5653f9cc922777b706563be7f4b0058d19c4/tests/test_rtcicetransport.py#L62-L67
as its consumer method actually takes care of the case as below:
https://github.com/aiortc/aiortc/blob/65cd5653f9cc922777b706563be7f4b0058d19c4/src/aiortc/rtcicetransport.py#L99

So this PR proposes to add the type hint for it.