### PR TITLE
Manipulate x509 certificates / private keys as cryptography objects

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,11 +29,11 @@ dependencies = [
     "aioice>=0.9.0,<1.0.0",
     "av>=9.0.0,<14.0.0",
     "cffi>=1.0.0",
-    "cryptography>=42.0.0",
+    "cryptography>=44.0.0",
     "google-crc32c>=1.1",
     "pyee>=13.0.0",
     "pylibsrtp>=0.10.0",
-    "pyopenssl>=24.0.0",
+    "pyopenssl>=25.0.0",
 ]
 dynamic = ["version"]
 


### PR DESCRIPTION
pyOpenSSL is deprecating its `x509.Cert` and `x509.PKey` classes in favour of their `cryptography.x509` equivalents.