### PR TITLE
Import `RTCRtpSender` directly from `aiortc` in webcam example

### DIFF
--- a/examples/webcam/webcam.py
+++ b/examples/webcam/webcam.py
@@ -7,9 +7,8 @@ import platform
 import ssl
 
 from aiohttp import web
-from aiortc import RTCPeerConnection, RTCSessionDescription
+from aiortc import RTCPeerConnection, RTCRtpSender, RTCSessionDescription
 from aiortc.contrib.media import MediaPlayer, MediaRelay
-from aiortc.rtcrtpsender import RTCRtpSender
 
 ROOT = os.path.dirname(__file__)
 


### PR DESCRIPTION
Clarify the fact our public API is importing from the `aiortc` module directly.