### PR TITLE
Don't touch PyAV's logging configuration

### DIFF
--- a/src/aiortc/__init__.py
+++ b/src/aiortc/__init__.py
@@ -1,8 +1,6 @@
 # ruff: noqa: F401
 import logging
 
-import av.logging
-
 from .exceptions import InvalidAccessError, InvalidStateError
 from .mediastreams import (
     AudioStreamTrack,
@@ -53,9 +51,6 @@ from .stats import (
 )
 
 __version__ = "1.11.0"
-
-# Disable PyAV's logging framework as it can lead to thread deadlocks.
-av.logging.restore_default_callback()
 
 # Set default logging handler to avoid "No handler found" warnings.
 logging.getLogger(__name__).addHandler(logging.NullHandler())


### PR DESCRIPTION
Nowadays PyAV's default logging configuration no longer causes deadlocks. Furthermore it is much less noisy as it suppresses FFmpeg's log messages.