### PR TITLE
Mark `RTCIceServer.urls` as being a list of strings

### DIFF
--- a/src/aiortc/rtcconfiguration.py
+++ b/src/aiortc/rtcconfiguration.py
@@ -10,16 +10,22 @@ class RTCIceServer:
     if any, to connect to the server.
     """
 
-    urls: str
+    urls: List[str]
     """
-    This required property is either a single string or a list of strings,
-    each specifying a URL which can be used to connect to the server.
+    This required property specifies a list of URLs which can be used to
+    connect to the server.
     """
     username: Optional[str] = None
     "The username to use during authentication (for TURN only)."
     credential: Optional[str] = None
     "The credential to use during authentication (for TURN only)."
     credentialType: str = "password"
+
+    def __post_init__(self):
+        # For backwards compatibility we accept a string, but convert it to
+        # a list with a single item.
+        if isinstance(self.urls, str):
+            self.urls = [self.urls]
 
 
 @dataclass

--- a/src/aiortc/rtcicetransport.py
+++ b/src/aiortc/rtcicetransport.py
@@ -96,12 +96,7 @@ def connection_kwargs(servers: List[RTCIceServer]) -> Dict[str, Any]:
     kwargs: Dict[str, Any] = {}
 
     for server in servers:
-        if isinstance(server.urls, list):
-            uris = server.urls
-        else:
-            uris = [server.urls]
-
-        for uri in uris:
+        for uri in server.urls:
             parsed = parse_stun_turn_uri(uri)
 
             if parsed["scheme"] == "stun":
@@ -206,7 +201,7 @@ class RTCIceGatherer(AsyncIOEventEmitter):
         """
         Return the list of default :class:`RTCIceServer`.
         """
-        return [RTCIceServer("stun:stun.l.google.com:19302")]
+        return [RTCIceServer(urls=["stun:stun.l.google.com:19302"])]
 
     def getLocalCandidates(self) -> List[RTCIceCandidate]:
         """

--- a/tests/test_rtcicetransport.py
+++ b/tests/test_rtcicetransport.py
@@ -32,6 +32,12 @@ class ConnectionKwargsTest(TestCase):
 
     def test_stun(self):
         self.assertEqual(
+            connection_kwargs([RTCIceServer(urls=["stun:stun.l.google.com:19302"])]),
+            {"stun_server": ("stun.l.google.com", 19302)},
+        )
+
+        # Backwards compatibility: `urls` as a string.
+        self.assertEqual(
             connection_kwargs([RTCIceServer("stun:stun.l.google.com:19302")]),
             {"stun_server": ("stun.l.google.com", 19302)},
         )
@@ -39,7 +45,7 @@ class ConnectionKwargsTest(TestCase):
     def test_stun_with_suffix(self):
         self.assertEqual(
             connection_kwargs(
-                [RTCIceServer("stun:global.stun.twilio.com:3478?transport=udp")]
+                [RTCIceServer(urls=["stun:global.stun.twilio.com:3478?transport=udp"])]
             ),
             {"stun_server": ("global.stun.twilio.com", 3478)},
         )
@@ -48,8 +54,8 @@ class ConnectionKwargsTest(TestCase):
         self.assertEqual(
             connection_kwargs(
                 [
-                    RTCIceServer("stun:stun.l.google.com:19302"),
-                    RTCIceServer("stun:stun.example.com"),
+                    RTCIceServer(urls=["stun:stun.l.google.com:19302"]),
+                    RTCIceServer(urls=["stun:stun.example.com"]),
                 ]
             ),
             {"stun_server": ("stun.l.google.com", 19302)},
@@ -60,7 +66,7 @@ class ConnectionKwargsTest(TestCase):
             connection_kwargs(
                 [
                     RTCIceServer(
-                        [
+                        urls=[
                             "stun:stun1.l.google.com:19302",
                             "stun:stun2.l.google.com:19302",
                         ]
@@ -72,7 +78,7 @@ class ConnectionKwargsTest(TestCase):
 
     def test_turn(self):
         self.assertEqual(
-            connection_kwargs([RTCIceServer("turn:turn.example.com")]),
+            connection_kwargs([RTCIceServer(urls=["turn:turn.example.com"])]),
             {
                 "turn_password": None,
                 "turn_server": ("turn.example.com", 3478),
@@ -86,8 +92,8 @@ class ConnectionKwargsTest(TestCase):
         self.assertEqual(
             connection_kwargs(
                 [
-                    RTCIceServer("turn:turn.example.com"),
-                    RTCIceServer("turn:turn.example.net"),
+                    RTCIceServer(urls=["turn:turn.example.com"]),
+                    RTCIceServer(urls=["turn:turn.example.net"]),
                 ]
             ),
             {
@@ -102,7 +108,11 @@ class ConnectionKwargsTest(TestCase):
     def test_turn_multiple_urls(self):
         self.assertEqual(
             connection_kwargs(
-                [RTCIceServer(["turn:turn1.example.com", "turn:turn2.example.com"])]
+                [
+                    RTCIceServer(
+                        urls=["turn:turn1.example.com", "turn:turn2.example.com"]
+                    )
+                ]
             ),
             {
                 "turn_password": None,
@@ -115,13 +125,17 @@ class ConnectionKwargsTest(TestCase):
 
     def test_turn_over_bogus(self):
         self.assertEqual(
-            connection_kwargs([RTCIceServer("turn:turn.example.com?transport=bogus")]),
+            connection_kwargs(
+                [RTCIceServer(urls=["turn:turn.example.com?transport=bogus"])]
+            ),
             {},
         )
 
     def test_turn_over_tcp(self):
         self.assertEqual(
-            connection_kwargs([RTCIceServer("turn:turn.example.com?transport=tcp")]),
+            connection_kwargs(
+                [RTCIceServer(urls=["turn:turn.example.com?transport=tcp"])]
+            ),
             {
                 "turn_password": None,
                 "turn_server": ("turn.example.com", 3478),
@@ -136,7 +150,7 @@ class ConnectionKwargsTest(TestCase):
             connection_kwargs(
                 [
                     RTCIceServer(
-                        urls="turn:turn.example.com", username="foo", credential="bar"
+                        urls=["turn:turn.example.com"], username="foo", credential="bar"
                     )
                 ]
             ),
@@ -154,7 +168,7 @@ class ConnectionKwargsTest(TestCase):
             connection_kwargs(
                 [
                     RTCIceServer(
-                        urls="turn:turn.example.com",
+                        urls=["turn:turn.example.com"],
                         username="foo",
                         credential="bar",
                         credentialType="token",
@@ -166,7 +180,7 @@ class ConnectionKwargsTest(TestCase):
 
     def test_turns(self):
         self.assertEqual(
-            connection_kwargs([RTCIceServer("turns:turn.example.com")]),
+            connection_kwargs([RTCIceServer(urls=["turns:turn.example.com"])]),
             {
                 "turn_password": None,
                 "turn_server": ("turn.example.com", 5349),
@@ -178,7 +192,9 @@ class ConnectionKwargsTest(TestCase):
 
     def test_turns_over_udp(self):
         self.assertEqual(
-            connection_kwargs([RTCIceServer("turns:turn.example.com?transport=udp")]),
+            connection_kwargs(
+                [RTCIceServer(urls=["turns:turn.example.com?transport=udp"])]
+            ),
             {},
         )
 
@@ -255,7 +271,7 @@ class RTCIceGathererTest(TestCase):
     def test_default_ice_servers(self):
         self.assertEqual(
             RTCIceGatherer.getDefaultIceServers(),
-            [RTCIceServer(urls="stun:stun.l.google.com:19302")],
+            [RTCIceServer(urls=["stun:stun.l.google.com:19302"])],
         )
 
 


### PR DESCRIPTION
This is an alternative proposal to #1270.