### PR TITLE
Drop obsolete code type hints

### DIFF
--- a/src/aiortc/codecs/_opus.pyi
+++ b/src/aiortc/codecs/_opus.pyi
@@ -1,4 +1,0 @@
-from typing import Any
-
-ffi: Any
-lib: Any

--- a/src/aiortc/codecs/_vpx.pyi
+++ b/src/aiortc/codecs/_vpx.pyi
@@ -1,4 +1,0 @@
-from typing import Any
-
-ffi: Any
-lib: Any


### PR DESCRIPTION
We no longer need type hints for the `_opus` and `_vpx` CFFI modules, they are gone.