### PR TITLE
Stop using deprecated type hints

### DIFF
--- a/src/aiortc/codecs/__init__.py
+++ b/src/aiortc/codecs/__init__.py
@@ -1,4 +1,4 @@
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
 from ..rtcrtpparameters import (
     ParametersDict,
@@ -22,7 +22,7 @@ PCMA_CODEC = RTCRtpCodecParameters(
     mimeType="audio/PCMA", clockRate=8000, channels=1, payloadType=8
 )
 
-CODECS: Dict[str, List[RTCRtpCodecParameters]] = {
+CODECS: dict[str, list[RTCRtpCodecParameters]] = {
     "audio": [
         RTCRtpCodecParameters(
             mimeType="audio/opus", clockRate=48000, channels=2, payloadType=96
@@ -35,7 +35,7 @@ CODECS: Dict[str, List[RTCRtpCodecParameters]] = {
 # Note, the id space for these extensions is shared across media types when BUNDLE
 # is negotiated. If you add a audio- or video-specific extension, make sure it has
 # a unique id.
-HEADER_EXTENSIONS: Dict[str, List[RTCRtpHeaderExtensionParameters]] = {
+HEADER_EXTENSIONS: dict[str, list[RTCRtpHeaderExtensionParameters]] = {
     "audio": [
         RTCRtpHeaderExtensionParameters(
             id=1, uri="urn:ietf:params:rtp-hdrext:sdes:mid"

--- a/src/aiortc/codecs/base.py
+++ b/src/aiortc/codecs/base.py
@@ -1,5 +1,4 @@
 from abc import ABCMeta, abstractmethod
-from typing import List, Tuple
 
 from av.frame import Frame
 from av.packet import Packet
@@ -9,7 +8,7 @@ from ..jitterbuffer import JitterFrame
 
 class Decoder(metaclass=ABCMeta):
     @abstractmethod
-    def decode(self, encoded_frame: JitterFrame) -> List[Frame]:
+    def decode(self, encoded_frame: JitterFrame) -> list[Frame]:
         pass  # pragma: no cover
 
 
@@ -17,9 +16,9 @@ class Encoder(metaclass=ABCMeta):
     @abstractmethod
     def encode(
         self, frame: Frame, force_keyframe: bool = False
-    ) -> Tuple[List[bytes], int]:
+    ) -> tuple[list[bytes], int]:
         pass  # pragma: no cover
 
     @abstractmethod
-    def pack(self, packet: Packet) -> Tuple[List[bytes], int]:
+    def pack(self, packet: Packet) -> tuple[list[bytes], int]:
         pass  # pragma: no cover

--- a/src/aiortc/codecs/g711.py
+++ b/src/aiortc/codecs/g711.py
@@ -1,5 +1,5 @@
 import fractions
-from typing import List, Tuple, cast
+from typing import cast
 
 from av import AudioFrame, AudioResampler, CodecContext
 from av.audio.codeccontext import AudioCodecContext
@@ -23,11 +23,11 @@ class PcmDecoder(Decoder):
         self.codec.layout = "mono"
         self.codec.sample_rate = SAMPLE_RATE
 
-    def decode(self, encoded_frame: JitterFrame) -> List[Frame]:
+    def decode(self, encoded_frame: JitterFrame) -> list[Frame]:
         packet = Packet(encoded_frame.data)
         packet.pts = encoded_frame.timestamp
         packet.time_base = TIME_BASE
-        return cast(List[Frame], self.codec.decode(packet))
+        return cast(list[Frame], self.codec.decode(packet))
 
 
 class PcmEncoder(Encoder):
@@ -48,7 +48,7 @@ class PcmEncoder(Encoder):
 
     def encode(
         self, frame: Frame, force_keyframe: bool = False
-    ) -> Tuple[List[bytes], int]:
+    ) -> tuple[list[bytes], int]:
         assert isinstance(frame, AudioFrame)
         assert frame.format.name == "s16"
         assert frame.layout.name in ["mono", "stereo"]
@@ -65,7 +65,7 @@ class PcmEncoder(Encoder):
             # No packets were returned due to buffering.
             return [], None
 
-    def pack(self, packet: Packet) -> Tuple[List[bytes], int]:
+    def pack(self, packet: Packet) -> tuple[list[bytes], int]:
         timestamp = convert_timebase(packet.pts, packet.time_base, TIME_BASE)
         return [bytes(packet)], timestamp
 

--- a/src/aiortc/codecs/opus.py
+++ b/src/aiortc/codecs/opus.py
@@ -1,5 +1,5 @@
 import fractions
-from typing import List, Optional, Tuple, cast
+from typing import Optional, cast
 
 from av import AudioFrame, AudioResampler, CodecContext
 from av.audio.codeccontext import AudioCodecContext
@@ -22,11 +22,11 @@ class OpusDecoder(Decoder):
         self.codec.layout = "stereo"
         self.codec.sample_rate = SAMPLE_RATE
 
-    def decode(self, encoded_frame: JitterFrame) -> List[Frame]:
+    def decode(self, encoded_frame: JitterFrame) -> list[Frame]:
         packet = Packet(encoded_frame.data)
         packet.pts = encoded_frame.timestamp
         packet.time_base = TIME_BASE
-        return cast(List[Frame], self.codec.decode(packet))
+        return cast(list[Frame], self.codec.decode(packet))
 
 
 class OpusEncoder(Encoder):
@@ -51,7 +51,7 @@ class OpusEncoder(Encoder):
 
     def encode(
         self, frame: Frame, force_keyframe: bool = False
-    ) -> Tuple[List[bytes], int]:
+    ) -> tuple[list[bytes], int]:
         assert isinstance(frame, AudioFrame)
         assert frame.format.name == "s16"
         assert frame.layout.name in ["mono", "stereo"]
@@ -73,6 +73,6 @@ class OpusEncoder(Encoder):
             # No packets were returned due to buffering.
             return [], None
 
-    def pack(self, packet: Packet) -> Tuple[List[bytes], int]:
+    def pack(self, packet: Packet) -> tuple[list[bytes], int]:
         timestamp = convert_timebase(packet.pts, packet.time_base, TIME_BASE)
         return [bytes(packet)], timestamp

--- a/src/aiortc/codecs/vpx.py
+++ b/src/aiortc/codecs/vpx.py
@@ -1,6 +1,6 @@
 import random
 from struct import pack, unpack_from
-from typing import List, Optional, Tuple, Type, TypeVar, cast
+from typing import Optional, Type, TypeVar, cast
 
 import av
 from av import CodecContext, VideoFrame
@@ -80,7 +80,7 @@ class VpxPayloadDescriptor:
         )
 
     @classmethod
-    def parse(cls: Type[DESCRIPTOR_T], data: bytes) -> Tuple[DESCRIPTOR_T, bytes]:
+    def parse(cls: Type[DESCRIPTOR_T], data: bytes) -> tuple[DESCRIPTOR_T, bytes]:
         if len(data) < 1:
             raise ValueError("VPX descriptor is too short")
 
@@ -155,11 +155,11 @@ class Vp8Decoder(Decoder):
     def __init__(self) -> None:
         self.codec = cast(VideoCodecContext, CodecContext.create("libvpx", "r"))
 
-    def decode(self, encoded_frame: JitterFrame) -> List[Frame]:
+    def decode(self, encoded_frame: JitterFrame) -> list[Frame]:
         packet = Packet(encoded_frame.data)
         packet.pts = encoded_frame.timestamp
         packet.time_base = VIDEO_TIME_BASE
-        return cast(List[Frame], self.codec.decode(packet))
+        return cast(list[Frame], self.codec.decode(packet))
 
 
 class Vp8Encoder(Encoder):
@@ -170,7 +170,7 @@ class Vp8Encoder(Encoder):
 
     def encode(
         self, frame: Frame, force_keyframe: bool = False
-    ) -> Tuple[List[bytes], int]:
+    ) -> tuple[list[bytes], int]:
         assert isinstance(frame, VideoFrame)
         if frame.format.name != "yuv420p":
             frame = frame.reformat(format="yuv420p")
@@ -224,7 +224,7 @@ class Vp8Encoder(Encoder):
         self.picture_id = (self.picture_id + 1) % (1 << 15)
         return payloads, timestamp
 
-    def pack(self, packet: Packet) -> Tuple[List[bytes], int]:
+    def pack(self, packet: Packet) -> tuple[list[bytes], int]:
         payloads = self._packetize(bytes(packet), self.picture_id)
         timestamp = convert_timebase(packet.pts, packet.time_base, VIDEO_TIME_BASE)
         self.picture_id = (self.picture_id + 1) % (1 << 15)
@@ -243,7 +243,7 @@ class Vp8Encoder(Encoder):
         self.__target_bitrate = bitrate
 
     @classmethod
-    def _packetize(cls, buffer: bytes, picture_id: int) -> List[bytes]:
+    def _packetize(cls, buffer: bytes, picture_id: int) -> list[bytes]:
         payloads = []
         descr = VpxPayloadDescriptor(
             partition_start=1, partition_id=0, picture_id=picture_id

--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -4,7 +4,7 @@ import fractions
 import logging
 import threading
 import time
-from typing import Dict, Optional, Set, Union
+from typing import Optional, Union
 
 import av
 from av import AudioFrame, VideoFrame
@@ -54,7 +54,7 @@ class MediaBlackhole:
     """
 
     def __init__(self) -> None:
-        self.__tracks: Dict[MediaStreamTrack, asyncio.Future] = {}
+        self.__tracks: dict[MediaStreamTrack, asyncio.Future] = {}
 
     def addTrack(self, track):
         """
@@ -309,7 +309,7 @@ class MediaPlayer:
         self.__thread_quit: Optional[threading.Event] = None
 
         # examine streams
-        self.__started: Set[PlayerStreamTrack] = set()
+        self.__started: set[PlayerStreamTrack] = set()
         self.__streams = []
         self.__decode = decode
         self.__audio: Optional[PlayerStreamTrack] = None
@@ -543,8 +543,8 @@ class MediaRelay:
     """
 
     def __init__(self) -> None:
-        self.__proxies: Dict[MediaStreamTrack, Set[RelayStreamTrack]] = {}
-        self.__tasks: Dict[MediaStreamTrack, asyncio.Future[None]] = {}
+        self.__proxies: dict[MediaStreamTrack, set[RelayStreamTrack]] = {}
+        self.__tasks: dict[MediaStreamTrack, asyncio.Future[None]] = {}
 
     def subscribe(
         self, track: MediaStreamTrack, buffered: bool = True

--- a/src/aiortc/jitterbuffer.py
+++ b/src/aiortc/jitterbuffer.py
@@ -1,4 +1,4 @@
-from typing import List, Optional, Tuple
+from typing import Optional
 
 from .rtp import RtpPacket
 from .utils import uint16_add
@@ -19,7 +19,7 @@ class JitterBuffer:
         assert capacity & (capacity - 1) == 0, "capacity must be a power of 2"
         self._capacity = capacity
         self._origin: Optional[int] = None
-        self._packets: List[Optional[RtpPacket]] = [None for i in range(capacity)]
+        self._packets: list[Optional[RtpPacket]] = [None for i in range(capacity)]
         self._prefetch = prefetch
         self._is_video = is_video
 
@@ -27,7 +27,7 @@ class JitterBuffer:
     def capacity(self) -> int:
         return self._capacity
 
-    def add(self, packet: RtpPacket) -> Tuple[bool, Optional[JitterFrame]]:
+    def add(self, packet: RtpPacket) -> tuple[bool, Optional[JitterFrame]]:
         pli_flag = False
         if self._origin is None:
             self._origin = packet.sequence_number
@@ -63,7 +63,7 @@ class JitterBuffer:
     def _remove_frame(self, sequence_number: int) -> Optional[JitterFrame]:
         frame = None
         frames = 0
-        packets: List[RtpPacket] = []
+        packets: list[RtpPacket] = []
         remove = 0
         timestamp = None
 

--- a/src/aiortc/mediastreams.py
+++ b/src/aiortc/mediastreams.py
@@ -3,7 +3,7 @@ import fractions
 import time
 import uuid
 from abc import ABCMeta, abstractmethod
-from typing import Tuple, Union
+from typing import Union
 
 from av import AudioFrame, VideoFrame
 from av.frame import Frame
@@ -118,7 +118,7 @@ class VideoStreamTrack(MediaStreamTrack):
     _start: float
     _timestamp: int
 
-    async def next_timestamp(self) -> Tuple[int, fractions.Fraction]:
+    async def next_timestamp(self) -> tuple[int, fractions.Fraction]:
         if self.readyState != "live":
             raise MediaStreamError
 

--- a/src/aiortc/rate.py
+++ b/src/aiortc/rate.py
@@ -1,6 +1,6 @@
 import math
 from enum import Enum
-from typing import Dict, List, Optional, Tuple
+from typing import Optional
 
 from aiortc.utils import uint32_add, uint32_gt
 
@@ -348,7 +348,7 @@ class OveruseEstimator:
         self._offset = 0.0
         self.previous_offset = 0.0
         self.slope = 1 / 64
-        self.ts_delta_hist: List[float] = []
+        self.ts_delta_hist: list[float] = []
 
         self.avg_noise = 0.0
         self.var_noise = 50.0
@@ -517,11 +517,11 @@ class RemoteBitrateEstimator:
         self.detector = OveruseDetector()
         self.rate_control = AimdRateControl()
         self.last_update_ms: Optional[int] = None
-        self.ssrcs: Dict[int, int] = {}
+        self.ssrcs: dict[int, int] = {}
 
     def add(
         self, arrival_time_ms: int, abs_send_time: int, payload_size: int, ssrc: int
-    ) -> Optional[Tuple[int, List[int]]]:
+    ) -> Optional[tuple[int, list[int]]]:
         timestamp = abs_send_time << 8
         update_estimate = False
 

--- a/src/aiortc/rtcconfiguration.py
+++ b/src/aiortc/rtcconfiguration.py
@@ -1,5 +1,5 @@
 from dataclasses import dataclass
-from typing import List, Optional, Union
+from typing import Optional, Union
 
 
 @dataclass
@@ -10,7 +10,7 @@ class RTCIceServer:
     if any, to connect to the server.
     """
 
-    urls: Union[str, List[str]]
+    urls: Union[str, list[str]]
     """
     This required property is either a single string or a list of strings,
     each specifying a URL which can be used to connect to the server.
@@ -29,5 +29,5 @@ class RTCConfiguration:
     options for an :class:`RTCPeerConnection`.
     """
 
-    iceServers: Optional[List[RTCIceServer]] = None
+    iceServers: Optional[list[RTCIceServer]] = None
     "A list of :class:`RTCIceServer` objects to configure STUN / TURN servers."

--- a/src/aiortc/rtcdtlstransport.py
+++ b/src/aiortc/rtcdtlstransport.py
@@ -6,7 +6,7 @@ import logging
 import os
 import traceback
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Protocol, Set, Type, TypeVar, Union
+from typing import Optional, Protocol, Type, TypeVar, Union
 
 import pylibsrtp
 from cryptography import x509
@@ -84,7 +84,7 @@ SRTP_AES128_CM_SHA1_80 = SRTPProtectionProfile(
 )
 
 # AES-GCM may not be available depending on how libsrtp2 was built.
-SRTP_PROFILES: List[SRTPProtectionProfile] = []
+SRTP_PROFILES: list[SRTPProtectionProfile] = []
 for srtp_profile in [
     SRTP_AEAD_AES_256_GCM,
     SRTP_AEAD_AES_128_GCM,
@@ -167,7 +167,7 @@ class RTCCertificate:
         """
         return self._cert.not_valid_after_utc
 
-    def getFingerprints(self) -> List[RTCDtlsFingerprint]:
+    def getFingerprints(self) -> list[RTCDtlsFingerprint]:
         """
         Returns the list of certificate fingerprints, one of which is computed
         with the digest algorithm used in the certificate signature.
@@ -192,7 +192,7 @@ class RTCCertificate:
         return cls(key=key, cert=cert)
 
     def _create_ssl_context(
-        self, srtp_profiles: List[SRTPProtectionProfile]
+        self, srtp_profiles: list[SRTPProtectionProfile]
     ) -> SSL.Context:
         ctx = SSL.Context(SSL.DTLS_METHOD)
         ctx.set_verify(
@@ -215,7 +215,7 @@ class RTCDtlsParameters:
     DTLS configuration.
     """
 
-    fingerprints: List[RTCDtlsFingerprint] = field(default_factory=list)
+    fingerprints: list[RTCDtlsFingerprint] = field(default_factory=list)
     "List of :class:`RTCDtlsFingerprint`, one fingerprint for each certificate."
 
     role: str = "auto"
@@ -242,17 +242,17 @@ class RtpRouter:
     """
 
     def __init__(self) -> None:
-        self.receivers: Set[RtpReceiver] = set()
-        self.senders: Dict[int, RtpSender] = {}
-        self.mid_table: Dict[str, RtpReceiver] = {}
-        self.ssrc_table: Dict[int, RtpReceiver] = {}
-        self.payload_type_table: Dict[int, Set[RtpReceiver]] = {}
+        self.receivers: set[RtpReceiver] = set()
+        self.senders: dict[int, RtpSender] = {}
+        self.mid_table: dict[str, RtpReceiver] = {}
+        self.ssrc_table: dict[int, RtpReceiver] = {}
+        self.payload_type_table: dict[int, set[RtpReceiver]] = {}
 
     def register_receiver(
         self,
         receiver: RtpReceiver,
-        ssrcs: List[int],
-        payload_types: List[int],
+        ssrcs: list[int],
+        payload_types: list[int],
         mid: Optional[str] = None,
     ):
         self.receivers.add(receiver)
@@ -268,8 +268,8 @@ class RtpRouter:
     def register_sender(self, sender, ssrc: int) -> None:
         self.senders[ssrc] = sender
 
-    def route_rtcp(self, packet: AnyRtcpPacket) -> Set[Union[RtpReceiver, RtpSender]]:
-        recipients: Set[Union[RtpReceiver, RtpSender]] = set()
+    def route_rtcp(self, packet: AnyRtcpPacket) -> set[Union[RtpReceiver, RtpSender]]:
+        recipients: set[Union[RtpReceiver, RtpSender]] = set()
 
         def add_recipient(recipient: Optional[Union[RtpReceiver, RtpSender]]) -> None:
             if recipient is not None:
@@ -343,7 +343,7 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
     """
 
     def __init__(
-        self, transport: RTCIceTransport, certificates: List[RTCCertificate]
+        self, transport: RTCIceTransport, certificates: list[RTCCertificate]
     ) -> None:
         assert len(certificates) == 1
         certificate = certificates[0]

--- a/src/aiortc/rtcicetransport.py
+++ b/src/aiortc/rtcicetransport.py
@@ -2,7 +2,7 @@ import asyncio
 import logging
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional
+from typing import Any, Optional
 
 from aioice import Candidate, Connection, ConnectionClosed
 from pyee.asyncio import AsyncIOEventEmitter
@@ -92,8 +92,8 @@ def candidate_to_aioice(x: RTCIceCandidate) -> Candidate:
     )
 
 
-def connection_kwargs(servers: List[RTCIceServer]) -> Dict[str, Any]:
-    kwargs: Dict[str, Any] = {}
+def connection_kwargs(servers: list[RTCIceServer]) -> dict[str, Any]:
+    kwargs: dict[str, Any] = {}
 
     for server in servers:
         if isinstance(server.urls, list):
@@ -137,7 +137,7 @@ def connection_kwargs(servers: List[RTCIceServer]) -> Dict[str, Any]:
     return kwargs
 
 
-def parse_stun_turn_uri(uri: str) -> Dict[str, Any]:
+def parse_stun_turn_uri(uri: str) -> dict[str, Any]:
     if uri.startswith("stun"):
         match = STUN_REGEX.fullmatch(uri)
     elif uri.startswith("turn"):
@@ -149,7 +149,7 @@ def parse_stun_turn_uri(uri: str) -> Dict[str, Any]:
         raise ValueError("malformed uri")
 
     # set port
-    parsed: Dict[str, Any] = match.groupdict()
+    parsed: dict[str, Any] = match.groupdict()
     if parsed["port"]:
         parsed["port"] = int(parsed["port"])
     elif parsed["scheme"] in ["stuns", "turns"]:
@@ -174,7 +174,7 @@ class RTCIceGatherer(AsyncIOEventEmitter):
     exchanged in signaling.
     """
 
-    def __init__(self, iceServers: Optional[List[RTCIceServer]] = None) -> None:
+    def __init__(self, iceServers: Optional[list[RTCIceServer]] = None) -> None:
         super().__init__()
 
         if iceServers is None:
@@ -202,13 +202,13 @@ class RTCIceGatherer(AsyncIOEventEmitter):
             self.__setState("completed")
 
     @classmethod
-    def getDefaultIceServers(cls) -> List[RTCIceServer]:
+    def getDefaultIceServers(cls) -> list[RTCIceServer]:
         """
         Return the list of default :class:`RTCIceServer`.
         """
         return [RTCIceServer("stun:stun.l.google.com:19302")]
 
-    def getLocalCandidates(self) -> List[RTCIceCandidate]:
+    def getLocalCandidates(self) -> list[RTCIceCandidate]:
         """
         Retrieve the list of valid local candidates associated with the ICE
         gatherer.
@@ -294,7 +294,7 @@ class RTCIceTransport(AsyncIOEventEmitter):
                     candidate_to_aioice(candidate)
                 )
 
-    def getRemoteCandidates(self) -> List[RTCIceCandidate]:
+    def getRemoteCandidates(self) -> list[RTCIceCandidate]:
         """
         Retrieve the list of candidates associated with the remote
         :class:`RTCIceTransport`.

--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -2,7 +2,7 @@ import asyncio
 import copy
 import logging
 import uuid
-from typing import Dict, List, Optional, Set, Union
+from typing import Optional, Union
 
 from pyee.asyncio import AsyncIOEventEmitter
 
@@ -50,8 +50,8 @@ logger = logging.getLogger(__name__)
 
 
 def filter_preferred_codecs(
-    codecs: List[RTCRtpCodecParameters], preferred: List[RTCRtpCodecCapability]
-) -> List[RTCRtpCodecParameters]:
+    codecs: list[RTCRtpCodecParameters], preferred: list[RTCRtpCodecCapability]
+) -> list[RTCRtpCodecParameters]:
     if not preferred:
         return codecs
 
@@ -80,11 +80,11 @@ def filter_preferred_codecs(
 
 
 def find_common_codecs(
-    local_codecs: List[RTCRtpCodecParameters],
-    remote_codecs: List[RTCRtpCodecParameters],
-) -> List[RTCRtpCodecParameters]:
+    local_codecs: list[RTCRtpCodecParameters],
+    remote_codecs: list[RTCRtpCodecParameters],
+) -> list[RTCRtpCodecParameters]:
     common = []
-    common_base: Dict[int, RTCRtpCodecParameters] = {}
+    common_base: dict[int, RTCRtpCodecParameters] = {}
     for c in remote_codecs:
         # for RTX, check we accepted the base codec
         if is_rtx(c):
@@ -111,9 +111,9 @@ def find_common_codecs(
 
 
 def find_common_header_extensions(
-    local_extensions: List[RTCRtpHeaderExtensionParameters],
-    remote_extensions: List[RTCRtpHeaderExtensionParameters],
-) -> List[RTCRtpHeaderExtensionParameters]:
+    local_extensions: list[RTCRtpHeaderExtensionParameters],
+    remote_extensions: list[RTCRtpHeaderExtensionParameters],
+) -> list[RTCRtpHeaderExtensionParameters]:
     common = []
     for rx in remote_extensions:
         for lx in local_extensions:
@@ -180,7 +180,7 @@ async def add_remote_candidates(
         await iceTransport.addRemoteCandidate(None)
 
 
-def allocate_mid(mids: Set[str]) -> str:
+def allocate_mid(mids: set[str]) -> str:
     """
     Allocate a MID which has not been used yet.
     """
@@ -295,22 +295,22 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         self.__certificates = [RTCCertificate.generateCertificate()]
         self.__cname = f"{uuid.uuid4()}"
         self.__configuration = configuration or RTCConfiguration()
-        self.__dtlsTransports: Set[RTCDtlsTransport] = set()
-        self.__iceTransports: Set[RTCIceTransport] = set()
-        self.__remoteDtls: Dict[
+        self.__dtlsTransports: set[RTCDtlsTransport] = set()
+        self.__iceTransports: set[RTCIceTransport] = set()
+        self.__remoteDtls: dict[
             Union[RTCRtpTransceiver, RTCSctpTransport], RTCDtlsParameters
         ] = {}
-        self.__remoteIce: Dict[
+        self.__remoteIce: dict[
             Union[RTCRtpTransceiver, RTCSctpTransport], RTCIceParameters
         ] = {}
-        self.__seenMids: Set[str] = set()
+        self.__seenMids: set[str] = set()
         self.__sctp: Optional[RTCSctpTransport] = None
         self.__sctp_mline_index: Optional[int] = None
         self._sctpLegacySdp = True
         self.__sctpRemotePort: Optional[int] = None
         self.__sctpRemoteCaps = None
         self.__stream_id = str(uuid.uuid4())
-        self.__transceivers: List[RTCRtpTransceiver] = []
+        self.__transceivers: list[RTCRtpTransceiver] = []
 
         self.__closeTask: Optional[asyncio.Task] = None
         self.__connectionState = "new"
@@ -634,11 +634,11 @@ class RTCPeerConnection(AsyncIOEventEmitter):
 
         def get_media(
             description: sdp.SessionDescription,
-        ) -> List[sdp.MediaDescription]:
+        ) -> list[sdp.MediaDescription]:
             return description.media if description else []
 
         def get_media_section(
-            media: List[sdp.MediaDescription], i: int
+            media: list[sdp.MediaDescription], i: int
         ) -> Optional[sdp.MediaDescription]:
             return media[i] if i < len(media) else None
 
@@ -700,14 +700,14 @@ class RTCPeerConnection(AsyncIOEventEmitter):
 
         return wrap_session_description(description)
 
-    def getReceivers(self) -> List[RTCRtpReceiver]:
+    def getReceivers(self) -> list[RTCRtpReceiver]:
         """
         Returns the list of :class:`RTCRtpReceiver` objects that are currently
         attached to the connection.
         """
         return list(map(lambda x: x.receiver, self.__transceivers))
 
-    def getSenders(self) -> List[RTCRtpSender]:
+    def getSenders(self) -> list[RTCRtpSender]:
         """
         Returns the list of :class:`RTCRtpSender` objects that are currently
         attached to the connection.
@@ -728,7 +728,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
             merged.update(report)
         return merged
 
-    def getTransceivers(self) -> List[RTCRtpTransceiver]:
+    def getTransceivers(self) -> list[RTCRtpTransceiver]:
         """
         Returns the list of :class:`RTCRtpTransceiver` objects that are currently
         attached to the connection.
@@ -832,7 +832,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         self.__validate_description(description, is_local=False)
 
         # apply description
-        iceCandidates: Dict[RTCIceTransport, sdp.MediaDescription] = {}
+        iceCandidates: dict[RTCIceTransport, sdp.MediaDescription] = {}
         trackEvents = []
         for i, media in enumerate(description.media):
             dtlsTransport: Optional[RTCDtlsTransport] = None
@@ -1138,7 +1138,7 @@ class RTCPeerConnection(AsyncIOEventEmitter):
             rtcp=media.rtp.rtcp,
         )
         if len(media.ssrc):
-            encodings: Dict[int, RTCRtpDecodingParameters] = {}
+            encodings: dict[int, RTCRtpDecodingParameters] = {}
             for codec in transceiver._codecs:
                 if is_rtx(codec):
                     apt = codec.parameters.get("apt")

--- a/src/aiortc/rtcrtpparameters.py
+++ b/src/aiortc/rtcrtpparameters.py
@@ -1,7 +1,7 @@
 from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Union
+from typing import Optional, Union
 
-ParametersDict = Dict[str, Union[int, str, None]]
+ParametersDict = dict[str, Union[int, str, None]]
 
 
 @dataclass
@@ -40,7 +40,7 @@ class RTCRtpCodecParameters:
     "The number of channels supported (e.g. two for stereo)."
     payloadType: Optional[int] = None
     "The value that goes in the RTP Payload Type Field."
-    rtcpFeedback: List["RTCRtcpFeedback"] = field(default_factory=list)
+    rtcpFeedback: list["RTCRtcpFeedback"] = field(default_factory=list)
     "Transport layer and codec-specific feedback messages for this codec."
     parameters: ParametersDict = field(default_factory=dict)
     "Codec-specific parameters available for signaling."
@@ -108,9 +108,9 @@ class RTCRtpCapabilities:
     support codecs and header extensions.
     """
 
-    codecs: List[RTCRtpCodecCapability] = field(default_factory=list)
+    codecs: list[RTCRtpCodecCapability] = field(default_factory=list)
     "A list of :class:`RTCRtpCodecCapability`."
-    headerExtensions: List[RTCRtpHeaderExtensionCapability] = field(
+    headerExtensions: list[RTCRtpHeaderExtensionCapability] = field(
         default_factory=list
     )
     "A list of :class:`RTCRtpHeaderExtensionCapability`."
@@ -148,9 +148,9 @@ class RTCRtpParameters:
     an :class:`RTCRtpReceiver` or an :class:`RTCRtpSender`.
     """
 
-    codecs: List[RTCRtpCodecParameters] = field(default_factory=list)
+    codecs: list[RTCRtpCodecParameters] = field(default_factory=list)
     "A list of :class:`RTCRtpCodecParameters` to send or receive."
-    headerExtensions: List[RTCRtpHeaderExtensionParameters] = field(
+    headerExtensions: list[RTCRtpHeaderExtensionParameters] = field(
         default_factory=list
     )
     "A list of :class:`RTCRtpHeaderExtensionParameters`."
@@ -162,9 +162,9 @@ class RTCRtpParameters:
 
 @dataclass
 class RTCRtpReceiveParameters(RTCRtpParameters):
-    encodings: List[RTCRtpDecodingParameters] = field(default_factory=list)
+    encodings: list[RTCRtpDecodingParameters] = field(default_factory=list)
 
 
 @dataclass
 class RTCRtpSendParameters(RTCRtpParameters):
-    encodings: List[RTCRtpEncodingParameters] = field(default_factory=list)
+    encodings: list[RTCRtpEncodingParameters] = field(default_factory=list)

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -6,7 +6,7 @@ import random
 import threading
 import time
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Optional, Set
+from typing import Callable, Optional
 
 from av.frame import Frame
 
@@ -76,7 +76,7 @@ def decoder_worker(loop, input_q, output_q):
 class NackGenerator:
     def __init__(self) -> None:
         self.max_seq: Optional[int] = None
-        self.missing: Set[int] = set()
+        self.missing: set[int] = set()
 
     def add(self, packet: RtpPacket) -> bool:
         """
@@ -264,8 +264,8 @@ class RTCRtpReceiver:
             raise InvalidStateError
 
         self._enabled = True
-        self.__active_ssrc: Dict[int, datetime.datetime] = {}
-        self.__codecs: Dict[int, RTCRtpCodecParameters] = {}
+        self.__active_ssrc: dict[int, datetime.datetime] = {}
+        self.__codecs: dict[int, RTCRtpCodecParameters] = {}
         self.__decoder_queue: queue.Queue = queue.Queue()
         self.__decoder_thread: Optional[threading.Thread] = None
         self.__kind = kind
@@ -281,16 +281,16 @@ class RTCRtpReceiver:
         self.__rtcp_exited = asyncio.Event()
         self.__rtcp_started = asyncio.Event()
         self.__rtcp_task: Optional[asyncio.Future[None]] = None
-        self.__rtx_ssrc: Dict[int, int] = {}
+        self.__rtx_ssrc: dict[int, int] = {}
         self.__started = False
         self.__stats = RTCStatsReport()
         self.__timestamp_mapper = TimestampMapper()
         self.__transport = transport
 
         # RTCP
-        self.__lsr: Dict[int, int] = {}
-        self.__lsr_time: Dict[int, float] = {}
-        self.__remote_streams: Dict[int, StreamStatistics] = {}
+        self.__lsr: dict[int, int] = {}
+        self.__lsr_time: dict[int, float] = {}
+        self.__remote_streams: dict[int, StreamStatistics] = {}
         self.__rtcp_ssrc: Optional[int] = None
 
         # logging
@@ -353,7 +353,7 @@ class RTCRtpReceiver:
 
         return self.__stats
 
-    def getSynchronizationSources(self) -> List[RTCRtpSynchronizationSource]:
+    def getSynchronizationSources(self) -> list[RTCRtpSynchronizationSource]:
         """
         Returns a :class:`RTCRtpSynchronizationSource` for each unique SSRC identifier
         received in the last 10 seconds.
@@ -587,7 +587,7 @@ class RTCRtpReceiver:
         except ConnectionError:
             pass
 
-    async def _send_rtcp_nack(self, media_ssrc: int, lost: List[int]) -> None:
+    async def _send_rtcp_nack(self, media_ssrc: int, lost: list[int]) -> None:
         """
         Send an RTCP packet to report missing RTP packets.
         """

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -4,7 +4,7 @@ import random
 import time
 import traceback
 import uuid
-from typing import Callable, Dict, List, Optional, Union
+from typing import Callable, Optional, Union
 
 from av import AudioFrame
 from av.frame import Frame
@@ -59,7 +59,7 @@ def random_sequence_number() -> int:
 
 
 class RTCEncodedFrame:
-    def __init__(self, payloads: List[bytes], timestamp: int, audio_level: int):
+    def __init__(self, payloads: list[bytes], timestamp: int, audio_level: int):
         self.payloads = payloads
         self.timestamp = timestamp
         self.audio_level = audio_level
@@ -100,7 +100,7 @@ class RTCRtpSender:
         self.__rtp_header_extensions_map = rtp.HeaderExtensionsMap()
         self.__rtp_started = asyncio.Event()
         self.__rtp_task: Optional[asyncio.Future[None]] = None
-        self.__rtp_history: Dict[int, RtpPacket] = {}
+        self.__rtp_history: dict[int, RtpPacket] = {}
         self.__rtcp_exited = asyncio.Event()
         self.__rtcp_started = asyncio.Event()
         self.__rtcp_task: Optional[asyncio.Future[None]] = None
@@ -422,7 +422,7 @@ class RTCRtpSender:
                 await asyncio.sleep(0.5 + random.random())
 
                 # RTCP SR
-                packets: List[AnyRtcpPacket] = [
+                packets: list[AnyRtcpPacket] = [
                     RtcpSrPacket(
                         ssrc=self._ssrc,
                         sender_info=RtcpSenderInfo(
@@ -460,7 +460,7 @@ class RTCRtpSender:
         self.__log_debug("- RTCP finished")
         self.__rtcp_exited.set()
 
-    async def _send_rtcp(self, packets: List[AnyRtcpPacket]) -> None:
+    async def _send_rtcp(self, packets: list[AnyRtcpPacket]) -> None:
         payload = b""
         for packet in packets:
             self.__log_debug("> %s", packet)

--- a/src/aiortc/rtcrtptransceiver.py
+++ b/src/aiortc/rtcrtptransceiver.py
@@ -1,5 +1,5 @@
 import logging
-from typing import List, Optional
+from typing import Optional
 
 from .codecs import get_capabilities
 from .rtcdtlstransport import RTCDtlsTransport
@@ -39,13 +39,13 @@ class RTCRtpTransceiver:
         self.__stopped = False
 
         self._offerDirection: Optional[str] = None
-        self._preferred_codecs: List[RTCRtpCodecCapability] = []
+        self._preferred_codecs: list[RTCRtpCodecCapability] = []
         self._transport: RTCDtlsTransport = None
 
         # FIXME: this is only used by RTCPeerConnection
         self._bundled = False
-        self._codecs: List[RTCRtpCodecParameters] = []
-        self._headerExtensions: List[RTCRtpHeaderExtensionParameters] = []
+        self._codecs: list[RTCRtpCodecParameters] = []
+        self._headerExtensions: list[RTCRtpHeaderExtensionParameters] = []
 
     @property
     def currentDirection(self) -> Optional[str]:
@@ -100,7 +100,7 @@ class RTCRtpTransceiver:
     def stopped(self) -> bool:
         return self.__stopped
 
-    def setCodecPreferences(self, codecs: List[RTCRtpCodecCapability]) -> None:
+    def setCodecPreferences(self, codecs: list[RTCRtpCodecCapability]) -> None:
         """
         Override the default codec preferences.
 
@@ -114,7 +114,7 @@ class RTCRtpTransceiver:
             self._preferred_codecs = []
 
         capabilities = get_capabilities(self.kind).codecs
-        unique: List[RTCRtpCodecCapability] = []
+        unique: list[RTCRtpCodecCapability] = []
         for codec in reversed(codecs):
             if codec not in capabilities:
                 raise ValueError("Codec is not in capabilities")

--- a/src/aiortc/rtp.py
+++ b/src/aiortc/rtp.py
@@ -3,7 +3,7 @@ import os
 import struct
 from dataclasses import dataclass, field
 from struct import pack, unpack, unpack_from
-from typing import Any, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from av import AudioFrame
 
@@ -170,7 +170,7 @@ def pack_rtcp_packet(packet_type: int, count: int, payload: bytes) -> bytes:
     return pack("!BBH", (2 << 6) | count, packet_type, len(payload) // 4) + payload
 
 
-def pack_remb_fci(bitrate: int, ssrcs: List[int]) -> bytes:
+def pack_remb_fci(bitrate: int, ssrcs: list[int]) -> bytes:
     """
     Pack the FCI for a Receiver Estimated Maximum Bitrate report.
 
@@ -190,7 +190,7 @@ def pack_remb_fci(bitrate: int, ssrcs: List[int]) -> bytes:
     return data
 
 
-def unpack_remb_fci(data: bytes) -> Tuple[int, List[int]]:
+def unpack_remb_fci(data: bytes) -> tuple[int, list[int]]:
     """
     Unpack the FCI for a Receiver Estimated Maximum Bitrate report.
 
@@ -225,7 +225,7 @@ def padl(length: int) -> int:
 
 def unpack_header_extensions(
     extension_profile: int, extension_value: bytes
-) -> List[Tuple[int, bytes]]:
+) -> list[tuple[int, bytes]]:
     """
     Parse header extensions according to RFC 5285.
     """
@@ -271,7 +271,7 @@ def unpack_header_extensions(
     return extensions
 
 
-def pack_header_extensions(extensions: List[Tuple[int, bytes]]) -> Tuple[int, bytes]:
+def pack_header_extensions(extensions: list[tuple[int, bytes]]) -> tuple[int, bytes]:
     """
     Serialize header extensions according to RFC 5285.
     """
@@ -395,12 +395,12 @@ class RtcpSenderInfo:
 @dataclass
 class RtcpSourceInfo:
     ssrc: int
-    items: List[Tuple[Any, bytes]]
+    items: list[tuple[Any, bytes]]
 
 
 @dataclass
 class RtcpByePacket:
-    sources: List[int]
+    sources: list[int]
 
     def __bytes__(self) -> bytes:
         payload = b"".join([pack("!L", ssrc) for ssrc in self.sources])
@@ -445,7 +445,7 @@ class RtcpPsfbPacket:
 @dataclass
 class RtcpRrPacket:
     ssrc: int
-    reports: List[RtcpReceiverInfo] = field(default_factory=list)
+    reports: list[RtcpReceiverInfo] = field(default_factory=list)
 
     def __bytes__(self) -> bytes:
         payload = pack("!L", self.ssrc)
@@ -478,7 +478,7 @@ class RtcpRtpfbPacket:
     media_ssrc: int
 
     # generick NACK
-    lost: List[int] = field(default_factory=list)
+    lost: list[int] = field(default_factory=list)
 
     def __bytes__(self) -> bytes:
         payload = pack("!LL", self.ssrc, self.media_ssrc)
@@ -514,7 +514,7 @@ class RtcpRtpfbPacket:
 
 @dataclass
 class RtcpSdesPacket:
-    chunks: List[RtcpSourceInfo] = field(default_factory=list)
+    chunks: list[RtcpSourceInfo] = field(default_factory=list)
 
     def __bytes__(self) -> bytes:
         payload = b""
@@ -558,7 +558,7 @@ class RtcpSdesPacket:
 class RtcpSrPacket:
     ssrc: int
     sender_info: RtcpSenderInfo
-    reports: List[RtcpReceiverInfo] = field(default_factory=list)
+    reports: list[RtcpReceiverInfo] = field(default_factory=list)
 
     def __bytes__(self) -> bytes:
         payload = pack("!L", self.ssrc)
@@ -594,7 +594,7 @@ AnyRtcpPacket = Union[
 
 class RtcpPacket:
     @classmethod
-    def parse(cls, data: bytes) -> List[AnyRtcpPacket]:
+    def parse(cls, data: bytes) -> list[AnyRtcpPacket]:
         pos = 0
         packets = []
 
@@ -655,7 +655,7 @@ class RtpPacket:
         self.sequence_number = sequence_number
         self.timestamp = timestamp
         self.ssrc = ssrc
-        self.csrc: List[int] = []
+        self.csrc: list[int] = []
         self.extensions = HeaderExtensions()
         self.payload = payload
         self.padding_size = 0

--- a/src/aiortc/sdp.py
+++ b/src/aiortc/sdp.py
@@ -2,7 +2,7 @@ import enum
 import ipaddress
 import re
 from dataclasses import dataclass
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any, Optional, Union
 
 from . import rtp
 from .rtcdtlstransport import RTCDtlsFingerprint, RTCDtlsParameters
@@ -135,7 +135,7 @@ def candidate_to_sdp(candidate: RTCIceCandidate) -> str:
     return sdp
 
 
-def grouplines(sdp: str) -> Tuple[List[str], List[List[str]]]:
+def grouplines(sdp: str) -> tuple[list[str], list[list[str]]]:
     session = []
     media = []
     for line in sdp.splitlines():
@@ -183,7 +183,7 @@ def parameters_to_sdp(parameters: ParametersDict) -> str:
     return ";".join(params)
 
 
-def parse_attr(line: str) -> Tuple[str, Optional[str]]:
+def parse_attr(line: str) -> tuple[str, Optional[str]]:
     if ":" in line:
         bits = line[2:].split(":", 1)
         return bits[0], bits[1]
@@ -191,7 +191,7 @@ def parse_attr(line: str) -> Tuple[str, Optional[str]]:
         return line[2:], None
 
 
-def parse_h264_profile_level_id(profile_str: str) -> Tuple[H264Profile, H264Level]:
+def parse_h264_profile_level_id(profile_str: str) -> tuple[H264Profile, H264Level]:
     if not isinstance(profile_str, str) or not re.match(
         "[0-9a-f]{6}", profile_str, re.I
     ):
@@ -219,13 +219,13 @@ def parse_h264_profile_level_id(profile_str: str) -> Tuple[H264Profile, H264Leve
 @dataclass
 class GroupDescription:
     semantic: str
-    items: List[Union[int, str]]
+    items: list[Union[int, str]]
 
     def __str__(self) -> str:
         return f"{self.semantic} {' '.join(map(str, self.items))}"
 
 
-def parse_group(dest: List[GroupDescription], value: str, type=str) -> None:
+def parse_group(dest: list[GroupDescription], value: str, type=str) -> None:
     bits = value.split()
     if bits:
         dest.append(GroupDescription(semantic=bits[0], items=list(map(type, bits[1:]))))
@@ -244,7 +244,7 @@ SSRC_INFO_ATTRS = ["cname", "msid", "mslabel", "label"]
 
 
 class MediaDescription:
-    def __init__(self, kind: str, port: int, profile: str, fmt: List[Any]) -> None:
+    def __init__(self, kind: str, port: int, profile: str, fmt: list[Any]) -> None:
         # rtp
         self.kind = kind
         self.port = port
@@ -259,8 +259,8 @@ class MediaDescription:
         self.rtcp_mux = False
 
         # ssrc
-        self.ssrc: List[SsrcDescription] = []
-        self.ssrc_group: List[GroupDescription] = []
+        self.ssrc: list[SsrcDescription] = []
+        self.ssrc_group: list[GroupDescription] = []
 
         # formats
         self.fmt = fmt
@@ -268,7 +268,7 @@ class MediaDescription:
 
         # SCTP
         self.sctpCapabilities: Optional[RTCSctpCapabilities] = None
-        self.sctpmap: Dict[int, str] = {}
+        self.sctpmap: dict[int, str] = {}
         self.sctp_port: Optional[int] = None
 
         # DTLS
@@ -276,7 +276,7 @@ class MediaDescription:
 
         # ICE
         self.ice: Optional[RTCIceParameters] = None
-        self.ice_candidates: List[RTCIceCandidate] = []
+        self.ice_candidates: list[RTCIceCandidate] = []
         self.ice_candidates_complete = False
         self.ice_options: Optional[str] = None
 
@@ -364,9 +364,9 @@ class SessionDescription:
         self.name = "-"
         self.time = "0 0"
         self.host: Optional[str] = None
-        self.group: List[GroupDescription] = []
-        self.msid_semantic: List[GroupDescription] = []
-        self.media: List[MediaDescription] = []
+        self.group: list[GroupDescription] = []
+        self.msid_semantic: list[GroupDescription] = []
+        self.media: list[MediaDescription] = []
         self.type: Optional[str] = None
 
     @classmethod
@@ -427,7 +427,7 @@ class SessionDescription:
             # check payload types are valid
             kind = m.group(1)
             fmt = m.group(4).split()
-            fmt_int: Optional[List[int]] = None
+            fmt_int: Optional[list[int]] = None
             if kind in ["audio", "video"]:
                 fmt_int = [int(x) for x in fmt]
                 for pt in fmt_int:

--- a/tests/test_mediastreams.py
+++ b/tests/test_mediastreams.py
@@ -1,7 +1,6 @@
 import asyncio
 import fractions
 import time
-from typing import Tuple
 from unittest import TestCase
 
 from aiortc.mediastreams import (
@@ -25,7 +24,7 @@ class VideoPacketStreamTrack(MediaStreamTrack):
     _start: float
     _timestamp: int
 
-    async def next_timestamp(self) -> Tuple[int, fractions.Fraction]:
+    async def next_timestamp(self) -> tuple[int, fractions.Fraction]:
         if hasattr(self, "_timestamp"):
             self._timestamp += int(VIDEO_PTIME * VIDEO_CLOCK_RATE)
             wait = self._start + (self._timestamp / VIDEO_CLOCK_RATE) - time.time()


### PR DESCRIPTION
Since we no longer support Python 3.8, we can use:

- `dict` instead of `typing.Dict`.
- `list` instead of `typing.List`.
- `set` instead of `typing.Set`.
- `tuple` instead of `typing.Tuple`