### PR TITLE
Update examples/server for Trickle ICE

### DIFF
--- a/examples/server/index.html
+++ b/examples/server/index.html
@@ -81,6 +81,10 @@
     <input id="use-stun" type="checkbox"/>
     <label for="use-stun">Use STUN server</label>
 </div>
+<div class="option">
+    <input id="use-trickle-ice" type="checkbox"/>
+    <label for="use-trickle-ice">Use Trickle ICE</label>
+</div>
 
 <button id="start" onclick="start()">Start</button>
 <button id="stop" style="display: none" onclick="stop()">Stop</button>


### PR DESCRIPTION
Add "Use Trickle ICE" option to the `example/server` app.

Trickle ICE is effective in a situation for example where the configured STUN server is unreachable but the peers already know each other.
For example, when the server and the client are in the same local network disconnected from the internet and `config.iceServers = [{ urls: ['stun:stun.l.google.com:19302'] }]` is set. This sometimes happens for example because you want to set the default STUN server for your app but you don't have full control about where the app will be used.
In such a case, the peers can establish the connection without asking STUN servers because they can obtain the target local IP addresses. However, if ICE is done in the Vanilla manner, each peer tries to connect to the configured STUN server and can't send the offer or answer until it's timed out as it's waiting for all ICE gathering to be done like [this code](https://github.com/aiortc/aiortc/blob/3ff9bdd03f22bf511a8d304df30f29392338a070/examples/server/client.js#L81-L94).
In contrast, if ICE is done as Trickle ICE, the peers can send offer and answer without waiting for ICE gathering and can establish the connection even before the ICE candidates are obtained if possible.