### PR TITLE
Add type annotations to unit tests

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -29,7 +29,7 @@ jobs:
           ruff check .
           ruff format --check --diff .
           check-manifest
-          mypy src
+          mypy src tests
 
   test:
     runs-on: ${{ matrix.os }}

--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -4,7 +4,7 @@ import fractions
 import logging
 import threading
 import time
-from typing import Optional, Union
+from typing import Optional, Union, cast
 
 import av
 from av import AudioFrame, VideoFrame
@@ -56,7 +56,7 @@ class MediaBlackhole:
     def __init__(self) -> None:
         self.__tracks: dict[MediaStreamTrack, asyncio.Future] = {}
 
-    def addTrack(self, track):
+    def addTrack(self, track: MediaStreamTrack) -> None:
         """
         Add a track whose media should be discarded.
 
@@ -396,7 +396,7 @@ class MediaRecorderContext:
     def __init__(self, stream) -> None:
         self.started = False
         self.stream = stream
-        self.task = None
+        self.task: Optional[asyncio.Task[None]] = None
 
 
 class MediaRecorder:
@@ -418,9 +418,9 @@ class MediaRecorder:
     :param options: Additional options to pass to FFmpeg.
     """
 
-    def __init__(self, file, format=None, options=None):
+    def __init__(self, file, format=None, options=None) -> None:
         self.__container = av.open(file=file, format=format, mode="w", options=options)
-        self.__tracks = {}
+        self.__tracks: dict[MediaStreamTrack, MediaRecorderContext] = {}
 
     def addTrack(self, track: MediaStreamTrack) -> None:
         """
@@ -443,7 +443,9 @@ class MediaRecorder:
                 stream = self.__container.add_stream("png", rate=30)
                 stream.pix_fmt = "rgb24"
             else:
-                stream = self.__container.add_stream("libx264", rate=30)
+                stream = cast(
+                    VideoStream, self.__container.add_stream("libx264", rate=30)
+                )
                 stream.pix_fmt = "yuv420p"
         self.__tracks[track] = MediaRecorderContext(stream)
 

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -14,7 +14,11 @@ from .codecs import get_capabilities, get_encoder, is_rtx
 from .codecs.base import Encoder
 from .exceptions import InvalidStateError
 from .mediastreams import MediaStreamError, MediaStreamTrack
-from .rtcrtpparameters import RTCRtpCodecParameters, RTCRtpSendParameters
+from .rtcrtpparameters import (
+    RTCRtpCapabilities,
+    RTCRtpCodecParameters,
+    RTCRtpSendParameters,
+)
 from .rtp import (
     RTCP_PSFB_APP,
     RTCP_PSFB_PLI,
@@ -146,7 +150,7 @@ class RTCRtpSender:
         return self.__transport
 
     @classmethod
-    def getCapabilities(self, kind):
+    def getCapabilities(self, kind: str) -> RTCRtpCapabilities:
         """
         Returns the most optimistic view of the system's capabilities for
         sending media of the given `kind`.

--- a/tests/codecs.py
+++ b/tests/codecs.py
@@ -9,7 +9,9 @@ from av.packet import Packet
 
 
 class CodecTestCase(TestCase):
-    def create_audio_frame(self, samples, pts, layout="mono", sample_rate=48000):
+    def create_audio_frame(
+        self, samples: int, pts: int, layout="mono", sample_rate=48000
+    ) -> AudioFrame:
         frame = AudioFrame(format="s16", layout=layout, samples=samples)
         for p in frame.planes:
             p.update(bytes(p.buffer_size))
@@ -18,7 +20,9 @@ class CodecTestCase(TestCase):
         frame.time_base = fractions.Fraction(1, sample_rate)
         return frame
 
-    def create_audio_frames(self, layout, sample_rate, count):
+    def create_audio_frames(
+        self, layout: str, sample_rate: int, count: int
+    ) -> list[AudioFrame]:
         frames = []
         timestamp = 0
         samples_per_frame = int(AUDIO_PTIME * sample_rate)
@@ -45,8 +49,13 @@ class CodecTestCase(TestCase):
         return packet
 
     def create_video_frame(
-        self, width, height, pts, format="yuv420p", time_base=VIDEO_TIME_BASE
-    ):
+        self,
+        width: int,
+        height: int,
+        pts: int,
+        format="yuv420p",
+        time_base=VIDEO_TIME_BASE,
+    ) -> VideoFrame:
         """
         Create a single blank video frame.
         """
@@ -57,7 +66,9 @@ class CodecTestCase(TestCase):
         frame.time_base = time_base
         return frame
 
-    def create_video_frames(self, width, height, count, time_base=VIDEO_TIME_BASE):
+    def create_video_frames(
+        self, width: int, height: int, count: int, time_base=VIDEO_TIME_BASE
+    ) -> list[VideoFrame]:
         """
         Create consecutive blank video frames.
         """

--- a/tests/test_rtcicetransport.py
+++ b/tests/test_rtcicetransport.py
@@ -27,16 +27,16 @@ async def mock_get_event():
 
 
 class ConnectionKwargsTest(TestCase):
-    def test_empty(self):
+    def test_empty(self) -> None:
         self.assertEqual(connection_kwargs([]), {})
 
-    def test_stun(self):
+    def test_stun(self) -> None:
         self.assertEqual(
             connection_kwargs([RTCIceServer("stun:stun.l.google.com:19302")]),
             {"stun_server": ("stun.l.google.com", 19302)},
         )
 
-    def test_stun_with_suffix(self):
+    def test_stun_with_suffix(self) -> None:
         self.assertEqual(
             connection_kwargs(
                 [RTCIceServer("stun:global.stun.twilio.com:3478?transport=udp")]
@@ -44,7 +44,7 @@ class ConnectionKwargsTest(TestCase):
             {"stun_server": ("global.stun.twilio.com", 3478)},
         )
 
-    def test_stun_multiple_servers(self):
+    def test_stun_multiple_servers(self) -> None:
         self.assertEqual(
             connection_kwargs(
                 [
@@ -55,7 +55,7 @@ class ConnectionKwargsTest(TestCase):
             {"stun_server": ("stun.l.google.com", 19302)},
         )
 
-    def test_stun_multiple_urls(self):
+    def test_stun_multiple_urls(self) -> None:
         self.assertEqual(
             connection_kwargs(
                 [
@@ -70,7 +70,7 @@ class ConnectionKwargsTest(TestCase):
             {"stun_server": ("stun1.l.google.com", 19302)},
         )
 
-    def test_turn(self):
+    def test_turn(self) -> None:
         self.assertEqual(
             connection_kwargs([RTCIceServer("turn:turn.example.com")]),
             {
@@ -82,7 +82,7 @@ class ConnectionKwargsTest(TestCase):
             },
         )
 
-    def test_turn_multiple_servers(self):
+    def test_turn_multiple_servers(self) -> None:
         self.assertEqual(
             connection_kwargs(
                 [
@@ -99,7 +99,7 @@ class ConnectionKwargsTest(TestCase):
             },
         )
 
-    def test_turn_multiple_urls(self):
+    def test_turn_multiple_urls(self) -> None:
         self.assertEqual(
             connection_kwargs(
                 [RTCIceServer(["turn:turn1.example.com", "turn:turn2.example.com"])]
@@ -113,13 +113,13 @@ class ConnectionKwargsTest(TestCase):
             },
         )
 
-    def test_turn_over_bogus(self):
+    def test_turn_over_bogus(self) -> None:
         self.assertEqual(
             connection_kwargs([RTCIceServer("turn:turn.example.com?transport=bogus")]),
             {},
         )
 
-    def test_turn_over_tcp(self):
+    def test_turn_over_tcp(self) -> None:
         self.assertEqual(
             connection_kwargs([RTCIceServer("turn:turn.example.com?transport=tcp")]),
             {
@@ -131,7 +131,7 @@ class ConnectionKwargsTest(TestCase):
             },
         )
 
-    def test_turn_with_password(self):
+    def test_turn_with_password(self) -> None:
         self.assertEqual(
             connection_kwargs(
                 [
@@ -149,7 +149,7 @@ class ConnectionKwargsTest(TestCase):
             },
         )
 
-    def test_turn_with_token(self):
+    def test_turn_with_token(self) -> None:
         self.assertEqual(
             connection_kwargs(
                 [
@@ -164,7 +164,7 @@ class ConnectionKwargsTest(TestCase):
             {},
         )
 
-    def test_turns(self):
+    def test_turns(self) -> None:
         self.assertEqual(
             connection_kwargs([RTCIceServer("turns:turn.example.com")]),
             {
@@ -176,7 +176,7 @@ class ConnectionKwargsTest(TestCase):
             },
         )
 
-    def test_turns_over_udp(self):
+    def test_turns_over_udp(self) -> None:
         self.assertEqual(
             connection_kwargs([RTCIceServer("turns:turn.example.com?transport=udp")]),
             {},
@@ -184,54 +184,54 @@ class ConnectionKwargsTest(TestCase):
 
 
 class ParseStunTurnUriTest(TestCase):
-    def test_invalid_scheme(self):
+    def test_invalid_scheme(self) -> None:
         with self.assertRaises(ValueError) as cm:
             parse_stun_turn_uri("foo")
         self.assertEqual(str(cm.exception), "malformed uri: invalid scheme")
 
-    def test_invalid_uri(self):
+    def test_invalid_uri(self) -> None:
         with self.assertRaises(ValueError) as cm:
             parse_stun_turn_uri("stun")
         self.assertEqual(str(cm.exception), "malformed uri")
 
-    def test_stun(self):
+    def test_stun(self) -> None:
         uri = parse_stun_turn_uri("stun:stun.services.mozilla.com")
         self.assertEqual(
             uri, {"host": "stun.services.mozilla.com", "port": 3478, "scheme": "stun"}
         )
 
-    def test_stuns(self):
+    def test_stuns(self) -> None:
         uri = parse_stun_turn_uri("stuns:stun.services.mozilla.com")
         self.assertEqual(
             uri, {"host": "stun.services.mozilla.com", "port": 5349, "scheme": "stuns"}
         )
 
-    def test_stun_with_port(self):
+    def test_stun_with_port(self) -> None:
         uri = parse_stun_turn_uri("stun:stun.l.google.com:19302")
         self.assertEqual(
             uri, {"host": "stun.l.google.com", "port": 19302, "scheme": "stun"}
         )
 
-    def test_turn(self):
+    def test_turn(self) -> None:
         uri = parse_stun_turn_uri("turn:1.2.3.4")
         self.assertEqual(
             uri, {"host": "1.2.3.4", "port": 3478, "scheme": "turn", "transport": "udp"}
         )
 
-    def test_turn_with_port_and_transport(self):
+    def test_turn_with_port_and_transport(self) -> None:
         uri = parse_stun_turn_uri("turn:1.2.3.4:3478?transport=tcp")
         self.assertEqual(
             uri, {"host": "1.2.3.4", "port": 3478, "scheme": "turn", "transport": "tcp"}
         )
 
-    def test_turns(self):
+    def test_turns(self) -> None:
         uri = parse_stun_turn_uri("turns:1.2.3.4")
         self.assertEqual(
             uri,
             {"host": "1.2.3.4", "port": 5349, "scheme": "turns", "transport": "tcp"},
         )
 
-    def test_turns_with_port_and_transport(self):
+    def test_turns_with_port_and_transport(self) -> None:
         uri = parse_stun_turn_uri("turns:1.2.3.4:1234?transport=tcp")
         self.assertEqual(
             uri,
@@ -241,7 +241,7 @@ class ParseStunTurnUriTest(TestCase):
 
 class RTCIceGathererTest(TestCase):
     @asynctest
-    async def test_gather(self):
+    async def test_gather(self) -> None:
         gatherer = RTCIceGatherer()
         self.assertEqual(gatherer.state, "new")
         self.assertEqual(gatherer.getLocalCandidates(), [])
@@ -252,7 +252,7 @@ class RTCIceGathererTest(TestCase):
         # close
         await gatherer._connection.close()
 
-    def test_default_ice_servers(self):
+    def test_default_ice_servers(self) -> None:
         self.assertEqual(
             RTCIceGatherer.getDefaultIceServers(),
             [RTCIceServer(urls="stun:stun.l.google.com:19302")],
@@ -260,7 +260,7 @@ class RTCIceGathererTest(TestCase):
 
 
 class RTCIceTransportTest(TestCase):
-    def setUp(self):
+    def setUp(self) -> None:
         # save timers
         self.consent_failures = aioice.ice.CONSENT_FAILURES
         self.consent_interval = aioice.ice.CONSENT_INTERVAL
@@ -273,7 +273,7 @@ class RTCIceTransportTest(TestCase):
         aioice.stun.RETRY_MAX = 1
         aioice.stun.RETRY_RTO = 0.1
 
-    def tearDown(self):
+    def tearDown(self) -> None:
         # restore timers
         aioice.ice.CONSENT_FAILURES = self.consent_failures
         aioice.ice.CONSENT_INTERVAL = self.consent_interval
@@ -281,7 +281,7 @@ class RTCIceTransportTest(TestCase):
         aioice.stun.RETRY_RTO = self.retry_rto
 
     @asynctest
-    async def test_construct(self):
+    async def test_construct(self) -> None:
         gatherer = RTCIceGatherer()
         connection = RTCIceTransport(gatherer)
         self.assertEqual(connection.state, "new")
@@ -306,7 +306,7 @@ class RTCIceTransportTest(TestCase):
         self.assertEqual(connection.getRemoteCandidates(), [candidate])
 
     @asynctest
-    async def test_connect(self):
+    async def test_connect(self) -> None:
         gatherer_1 = RTCIceGatherer()
         transport_1 = RTCIceTransport(gatherer_1)
 
@@ -336,7 +336,7 @@ class RTCIceTransportTest(TestCase):
         self.assertEqual(transport_2.state, "closed")
 
     @asynctest
-    async def test_connect_fail(self):
+    async def test_connect_fail(self) -> None:
         gatherer_1 = RTCIceGatherer()
         transport_1 = RTCIceTransport(gatherer_1)
 
@@ -364,7 +364,7 @@ class RTCIceTransportTest(TestCase):
         self.assertEqual(transport_2.state, "closed")
 
     @asynctest
-    async def test_connect_then_consent_expires(self):
+    async def test_connect_then_consent_expires(self) -> None:
         gatherer_1 = RTCIceGatherer()
         transport_1 = RTCIceTransport(gatherer_1)
 
@@ -400,7 +400,7 @@ class RTCIceTransportTest(TestCase):
         self.assertEqual(transport_2.state, "closed")
 
     @asynctest
-    async def test_connect_when_closed(self):
+    async def test_connect_when_closed(self) -> None:
         gatherer = RTCIceGatherer()
         transport = RTCIceTransport(gatherer)
 
@@ -416,12 +416,12 @@ class RTCIceTransportTest(TestCase):
         self.assertEqual(str(cm.exception), "RTCIceTransport is closed")
 
     @asynctest
-    async def test_connection_closed(self):
+    async def test_connection_closed(self) -> None:
         gatherer = RTCIceGatherer()
 
         # mock out methods
-        gatherer._connection.connect = mock_connect
-        gatherer._connection.get_event = mock_get_event
+        gatherer._connection.connect = mock_connect  # type: ignore
+        gatherer._connection.get_event = mock_get_event  # type: ignore
 
         transport = RTCIceTransport(gatherer)
         self.assertEqual(transport.state, "new")

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -3,11 +3,20 @@ import contextlib
 import functools
 import logging
 import os
+import sys
+from typing import Callable, Coroutine
+
+if sys.version_info >= (3, 10):
+    from typing import ParamSpec
+else:
+    from typing_extensions import ParamSpec
 
 from aiortc.rtcdtlstransport import RTCCertificate, RTCDtlsTransport
 
+P = ParamSpec("P")
 
-def lf2crlf(x):
+
+def lf2crlf(x: str) -> str:
     return x.replace("\n", "\r\n")
 
 
@@ -65,7 +74,9 @@ class DummyIceTransport:
         await self._connection.send(data)
 
 
-def asynctest(coro):
+def asynctest(
+    coro: Callable[P, Coroutine[None, None, None]],
+) -> Callable[P, None]:
     @functools.wraps(coro)
     def wrap(*args, **kwargs):
         asyncio.run(coro(*args, **kwargs))


### PR DESCRIPTION
Adding type annotations to unit tests allows `mypy` to shake out missing or incorrect type annotations in our code.