### PR TITLE
Remove redundant `CodecContext` type casting

### DIFF
--- a/src/aiortc/codecs/g711.py
+++ b/src/aiortc/codecs/g711.py
@@ -1,8 +1,7 @@
 import fractions
-from typing import cast
+from typing import Literal, cast
 
 from av import AudioFrame, AudioResampler, CodecContext
-from av.audio.codeccontext import AudioCodecContext
 from av.frame import Frame
 from av.packet import Packet
 
@@ -17,8 +16,8 @@ TIME_BASE = fractions.Fraction(1, 8000)
 
 
 class PcmDecoder(Decoder):
-    def __init__(self, codec_name: str) -> None:
-        self.codec = cast(AudioCodecContext, CodecContext.create(codec_name, "r"))
+    def __init__(self, codec_name: Literal["pcm_alaw", "pcm_mulaw"]) -> None:
+        self.codec = CodecContext.create(codec_name, "r")
         self.codec.format = "s16"
         self.codec.layout = "mono"
         self.codec.sample_rate = SAMPLE_RATE
@@ -31,8 +30,8 @@ class PcmDecoder(Decoder):
 
 
 class PcmEncoder(Encoder):
-    def __init__(self, codec_name: str) -> None:
-        self.codec = cast(AudioCodecContext, CodecContext.create(codec_name, "w"))
+    def __init__(self, codec_name: Literal["pcm_alaw", "pcm_mulaw"]) -> None:
+        self.codec = CodecContext.create(codec_name, "w")
         self.codec.format = "s16"
         self.codec.layout = "mono"
         self.codec.sample_rate = SAMPLE_RATE

--- a/src/aiortc/codecs/opus.py
+++ b/src/aiortc/codecs/opus.py
@@ -2,7 +2,6 @@ import fractions
 from typing import Optional, cast
 
 from av import AudioFrame, AudioResampler, CodecContext
-from av.audio.codeccontext import AudioCodecContext
 from av.frame import Frame
 from av.packet import Packet
 
@@ -17,7 +16,7 @@ TIME_BASE = fractions.Fraction(1, SAMPLE_RATE)
 
 class OpusDecoder(Decoder):
     def __init__(self) -> None:
-        self.codec = cast(AudioCodecContext, CodecContext.create("libopus", "r"))
+        self.codec = CodecContext.create("libopus", "r")
         self.codec.format = "s16"
         self.codec.layout = "stereo"
         self.codec.sample_rate = SAMPLE_RATE
@@ -31,7 +30,7 @@ class OpusDecoder(Decoder):
 
 class OpusEncoder(Encoder):
     def __init__(self) -> None:
-        self.codec = cast(AudioCodecContext, CodecContext.create("libopus", "w"))
+        self.codec = CodecContext.create("libopus", "w")
         self.codec.bit_rate = 96000
         self.codec.format = "s16"
         self.codec.layout = "stereo"

--- a/src/aiortc/codecs/vpx.py
+++ b/src/aiortc/codecs/vpx.py
@@ -153,7 +153,7 @@ class VpxPayloadDescriptor:
 
 class Vp8Decoder(Decoder):
     def __init__(self) -> None:
-        self.codec = cast(VideoCodecContext, CodecContext.create("libvpx", "r"))
+        self.codec = CodecContext.create("libvpx", "r")
 
     def decode(self, encoded_frame: JitterFrame) -> list[Frame]:
         packet = Packet(encoded_frame.data)
@@ -189,7 +189,7 @@ class Vp8Encoder(Encoder):
             frame.pict_type = av.video.frame.PictureType.I
 
         if self.codec is None:
-            self.codec = cast(VideoCodecContext, av.CodecContext.create("libvpx", "w"))
+            self.codec = av.CodecContext.create("libvpx", "w")
             self.codec.width = frame.width
             self.codec.height = frame.height
             self.codec.bit_rate = self.target_bitrate

--- a/src/aiortc/contrib/media.py
+++ b/src/aiortc/contrib/media.py
@@ -4,7 +4,7 @@ import fractions
 import logging
 import threading
 import time
-from typing import Optional, Union, cast
+from typing import Optional, Union
 
 import av
 from av import AudioFrame, VideoFrame
@@ -443,9 +443,7 @@ class MediaRecorder:
                 stream = self.__container.add_stream("png", rate=30)
                 stream.pix_fmt = "rgb24"
             else:
-                stream = cast(
-                    VideoStream, self.__container.add_stream("libx264", rate=30)
-                )
+                stream = self.__container.add_stream("libx264", rate=30)
                 stream.pix_fmt = "yuv420p"
         self.__tracks[track] = MediaRecorderContext(stream)
 

--- a/tests/test_contrib_media.py
+++ b/tests/test_contrib_media.py
@@ -4,7 +4,6 @@ import os
 import tempfile
 import time
 import wave
-from typing import cast
 from unittest import TestCase
 from unittest.mock import patch
 
@@ -59,9 +58,7 @@ class MediaTestCase(CodecTestCase):
         audio_samples = audio_rate // video_rate
 
         container = av.open(path, "w")
-        audio_stream = cast(
-            av.AudioStream, container.add_stream("libopus", rate=audio_rate)
-        )
+        audio_stream = container.add_stream("libopus", rate=audio_rate)
         video_stream = container.add_stream("h264", rate=video_rate)
         for video_frame in self.create_video_frames(
             width=width, height=height, count=duration * video_rate


### PR DESCRIPTION
PyAV 14.3.0 has narrowed the types of audio / video codec contexts.