### PR TITLE
fix: Fix the octet_count overflow issue by modifying the _run_rtcp function of the RTCRtpSender class

### DIFF
--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -432,8 +432,8 @@ class RTCRtpSender:
                         sender_info=RtcpSenderInfo(
                             ntp_timestamp=self.__ntp_timestamp,
                             rtp_timestamp=self.__rtp_timestamp,
-                            packet_count=self.__packet_count,
-                            octet_count=self.__octet_count,
+                            packet_count=self.__packet_count & 0xFFFFFFFF,
+                            octet_count=self.__octet_count & 0xFFFFFFFF,
                         ),
                     )
                 ]


### PR DESCRIPTION
When the RTCRtpSender operates continuously for approximately 2 hours or longer, the octet_count in RtcpSenderInfo may overflow. This can cause the RTCP component to cease transmission, thereby disrupting the audio-video synchronization mechanism and resulting in severe desynchronization during playback at the receiver's end.

The error displayed was `__bytes exception: 'L' format requires 0 <= number <= 4294967295.`

In Chrome's WebRTC C++ implementation, octet_count is implicitly converted to the uint32_t type, effectively performing a high-bit truncation. In Python, the same logic can be achieved using `& 0xFFFFFFFF` , thereby preventing overflow issues.