### PR TITLE
avoid having a transceiver._transport

### DIFF
--- a/src/aiortc/rtcrtptransceiver.py
+++ b/src/aiortc/rtcrtptransceiver.py
@@ -2,7 +2,6 @@ import logging
 from typing import Optional
 
 from .codecs import get_capabilities
-from .rtcdtlstransport import RTCDtlsTransport
 from .rtcrtpparameters import (
     RTCRtpCodecCapability,
     RTCRtpCodecParameters,
@@ -40,7 +39,6 @@ class RTCRtpTransceiver:
 
         self._offerDirection: Optional[str] = None
         self._preferred_codecs: list[RTCRtpCodecCapability] = []
-        self._transport: RTCDtlsTransport = None
 
         # FIXME: this is only used by RTCPeerConnection
         self._bundled = False
@@ -129,13 +127,6 @@ class RTCRtpTransceiver:
         await self.__receiver.stop()
         await self.__sender.stop()
         self.__stopped = True
-
-    @property
-    def transport(self) -> RTCDtlsTransport:
-        """
-        The :class:`RTCDtlsTransport` over which media are transmitted.
-        """
-        return self._transport
 
     def _setCurrentDirection(self, direction: str) -> None:
         self.__currentDirection = direction

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -5247,11 +5247,17 @@ a=rtpmap:0 PCMU/8000
         transceiver2 = pc.addTransceiver("video")
 
         await pc.createOffer()
-        param1 = transceiver1.transport.transport.iceGatherer.getLocalParameters()
-        param2 = transceiver2.transport.transport.iceGatherer.getLocalParameters()
+        param1 = (
+            transceiver1.receiver.transport.transport.iceGatherer.getLocalParameters()
+        )
+        param2 = (
+            transceiver2.receiver.transport.transport.iceGatherer.getLocalParameters()
+        )
         self.assertEqual(param1.usernameFragment, param2.usernameFragment)
         self.assertEqual(param1.password, param2.password)
-        self.assertEqual(transceiver1.transport, transceiver2.transport)
+        self.assertEqual(
+            transceiver1.receiver.transport, transceiver2.receiver.transport
+        )
 
     @asynctest
     async def test_bundlepolicy_max_bundle_ufrag_and_pwd_datachannel(self):
@@ -5262,11 +5268,13 @@ a=rtpmap:0 PCMU/8000
         transceiver = pc.addTransceiver("audio")
 
         await pc.createOffer()
-        param1 = transceiver.transport.transport.iceGatherer.getLocalParameters()
+        param1 = (
+            transceiver.receiver.transport.transport.iceGatherer.getLocalParameters()
+        )
         param2 = pc.sctp.transport.transport.iceGatherer.getLocalParameters()
         self.assertEqual(param1.usernameFragment, param2.usernameFragment)
         self.assertEqual(param1.password, param2.password)
-        self.assertEqual(transceiver.transport, pc.sctp.transport)
+        self.assertEqual(transceiver.receiver.transport, pc.sctp.transport)
 
     @asynctest
     async def test_bundlepolicy_transports_balanced(self):
@@ -5275,10 +5283,14 @@ a=rtpmap:0 PCMU/8000
         transceiver2 = pc.addTransceiver("video")
         transceiver3 = pc.addTransceiver("audio")
         pc.createDataChannel("somechannel")
-        self.assertNotEqual(transceiver1.transport, transceiver2.transport)
-        self.assertEqual(transceiver1.transport, transceiver3.transport)
-        self.assertNotEqual(transceiver1.transport, pc.sctp.transport)
-        self.assertNotEqual(transceiver2.transport, pc.sctp.transport)
+        self.assertNotEqual(
+            transceiver1.receiver.transport, transceiver2.receiver.transport
+        )
+        self.assertEqual(
+            transceiver1.receiver.transport, transceiver3.receiver.transport
+        )
+        self.assertNotEqual(transceiver1.receiver.transport, pc.sctp.transport)
+        self.assertNotEqual(transceiver2.receiver.transport, pc.sctp.transport)
 
     @asynctest
     async def test_bundlepolicy_transports_max_compat(self):
@@ -5289,10 +5301,14 @@ a=rtpmap:0 PCMU/8000
         transceiver2 = pc.addTransceiver("video")
         transceiver3 = pc.addTransceiver("audio")
         pc.createDataChannel("somechannel")
-        self.assertNotEqual(transceiver1.transport, transceiver2.transport)
-        self.assertNotEqual(transceiver1.transport, transceiver3.transport)
-        self.assertNotEqual(transceiver1.transport, pc.sctp.transport)
-        self.assertNotEqual(transceiver2.transport, pc.sctp.transport)
+        self.assertNotEqual(
+            transceiver1.receiver.transport, transceiver2.receiver.transport
+        )
+        self.assertNotEqual(
+            transceiver1.receiver.transport, transceiver3.receiver.transport
+        )
+        self.assertNotEqual(transceiver1.receiver.transport, pc.sctp.transport)
+        self.assertNotEqual(transceiver2.receiver.transport, pc.sctp.transport)
 
     @asynctest
     async def test_bundlepolicy_transports_max_bundle(self):
@@ -5303,6 +5319,10 @@ a=rtpmap:0 PCMU/8000
         transceiver2 = pc.addTransceiver("video")
         transceiver3 = pc.addTransceiver("audio")
         pc.createDataChannel("somechannel")
-        self.assertEqual(transceiver1.transport, transceiver2.transport)
-        self.assertEqual(transceiver1.transport, transceiver3.transport)
-        self.assertEqual(transceiver1.transport, pc.sctp.transport)
+        self.assertEqual(
+            transceiver1.receiver.transport, transceiver2.receiver.transport
+        )
+        self.assertEqual(
+            transceiver1.receiver.transport, transceiver3.receiver.transport
+        )
+        self.assertEqual(transceiver1.receiver.transport, pc.sctp.transport)


### PR DESCRIPTION
instead accesss it via the receivers transport. This is somewhat arbitrary since senders and receivers always exist but similar to how a transceivers receiver track is always set so you can get the "transceiver kind" from it.

Also remove transceiver.transport accessor added in
  https://github.com/aiortc/aiortc/pull/1229#discussion_r1938353163