### PR TITLE
reject stun urls with transport set

### DIFF
--- a/tests/test_rtcicetransport.py
+++ b/tests/test_rtcicetransport.py
@@ -36,12 +36,11 @@ class ConnectionKwargsTest(TestCase):
             {"stun_server": ("stun.l.google.com", 19302)},
         )
 
-    def test_stun_with_suffix(self) -> None:
+    def test_stun_with_transport(self) -> None:
+        with self.assertRaises(ValueError) as cm:
+            parse_stun_turn_uri("stun:global.stun.twilio.com:3478?transport=udp")
         self.assertEqual(
-            connection_kwargs(
-                [RTCIceServer("stun:global.stun.twilio.com:3478?transport=udp")]
-            ),
-            {"stun_server": ("global.stun.twilio.com", 3478)},
+            str(cm.exception), "malformed uri: stun must not contain transport"
         )
 
     def test_stun_multiple_servers(self) -> None:


### PR DESCRIPTION
which has been rejected in Chrome since early 2023:
  https://chromiumdash.appspot.com/commits?commit=f4d463ca875f51c26a7de0e594eb1516f3e60111