### PR TITLE
Limit the number of threads for VP8 encoding

### DIFF
--- a/tests/test_vpx.py
+++ b/tests/test_vpx.py
@@ -2,7 +2,12 @@ import fractions
 from unittest import TestCase
 
 from aiortc.codecs import get_decoder, get_encoder
-from aiortc.codecs.vpx import Vp8Decoder, Vp8Encoder, VpxPayloadDescriptor
+from aiortc.codecs.vpx import (
+    Vp8Decoder,
+    Vp8Encoder,
+    VpxPayloadDescriptor,
+    number_of_threads,
+)
 from aiortc.rtcrtpparameters import RTCRtpCodecParameters
 
 from .codecs import CodecTestCase
@@ -233,6 +238,12 @@ class Vp8Test(CodecTestCase):
         self.assertEqual(len(payloads), 1)
         self.assertTrue(len(payloads[0]) < 1300)
         self.assertAlmostEqual(timestamp, 3000, delta=1)
+
+    def test_number_of_threads(self) -> None:
+        self.assertEqual(number_of_threads(1920 * 1080, 16), 8)
+        self.assertEqual(number_of_threads(1920 * 1080, 8), 3)
+        self.assertEqual(number_of_threads(1920 * 1080, 4), 2)
+        self.assertEqual(number_of_threads(1920 * 1080, 2), 1)
 
     def test_roundtrip_1280_720(self) -> None:
         self.roundtrip_video(VP8_CODEC, 1280, 720)


### PR DESCRIPTION
When we switched to using PyAV for VP8 encoding we dropped the logic which defined the number of threads to use for encoding. This results in using as many threads as there are CPUs:

https://github.com/FFmpeg/FFmpeg/blob/b6f84cd72acd84ba725922bd6a8967b416b2230a/libavcodec/libvpxenc.c#L1014

Restore the previous behaviour.