### PR TITLE
Handle VP8 decoding errors to avoid stopping the decoding thread

### DIFF
--- a/tests/test_vpx.py
+++ b/tests/test_vpx.py
@@ -1,4 +1,6 @@
 import fractions
+import io
+from contextlib import redirect_stderr
 from unittest import TestCase
 
 from aiortc.codecs import get_decoder, get_encoder
@@ -8,6 +10,7 @@ from aiortc.codecs.vpx import (
     VpxPayloadDescriptor,
     number_of_threads,
 )
+from aiortc.jitterbuffer import JitterFrame
 from aiortc.rtcrtpparameters import RTCRtpCodecParameters
 
 from .codecs import CodecTestCase
@@ -160,6 +163,11 @@ class Vp8Test(CodecTestCase):
     def test_decoder(self) -> None:
         decoder = get_decoder(VP8_CODEC)
         self.assertIsInstance(decoder, Vp8Decoder)
+
+        # decode junk
+        with redirect_stderr(io.StringIO()):
+            frames = decoder.decode(JitterFrame(data=b"123", timestamp=0))
+        self.assertEqual(frames, [])
 
     def test_encoder(self) -> None:
         encoder = self.ensureIsInstance(get_encoder(VP8_CODEC), Vp8Encoder)


### PR DESCRIPTION
When we switched to using PyAV for VP8 encoding, we stopped handling the case where decoding a package fails. This causes the decoding thread to stop, breaking video reception. Apply the same logic we use for H.264 decoding : if we are unable to decode a package, log a warning and return an empty list of frames.

Fixes: #1315