### PR TITLE
only update remote description if it exists

### DIFF
--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -434,15 +434,16 @@ class RTCPeerConnection(AsyncIOEventEmitter):
             await iceTransport.addRemoteCandidate(candidate)
 
         # Update the remote description.
-        media = self.__remoteDescription().media
-        for sdp_m_line_index in range(0, len(media)):
-            if candidate is None:
-                media[sdp_m_line_index].ice_candidates_complete = True
-            elif (
-                candidate.sdpMLineIndex == sdp_m_line_index
-                or candidate.sdpMid == media[sdp_m_line_index].rtp.muxId
-            ):
-                media[sdp_m_line_index].ice_candidates.append(candidate)
+        if self.__remoteDescription():
+            media = self.__remoteDescription().media
+            for sdp_m_line_index in range(0, len(media)):
+                if candidate is None:
+                    media[sdp_m_line_index].ice_candidates_complete = True
+                elif (
+                    candidate.sdpMLineIndex == sdp_m_line_index
+                    or candidate.sdpMid == media[sdp_m_line_index].rtp.muxId
+                ):
+                    media[sdp_m_line_index].ice_candidates.append(candidate)
 
     def addTrack(self, track: MediaStreamTrack) -> RTCRtpSender:
         """

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -640,6 +640,24 @@ class RTCPeerConnectionTest(TestCase):
         self.assertTrue("a=end-of-candidates" in pc.remoteDescription.sdp)
 
     @asynctest
+    async def test_addIceCandidate_before_setremotedescription(self) -> None:
+        pc = RTCPeerConnection()
+        pc.createDataChannel("test")
+        offer = await pc.createOffer()
+        await pc.setLocalDescription(offer)
+        candidate_with_index = RTCIceCandidate(
+            component=1,
+            foundation="0",
+            ip="192.168.99.7",
+            port=33543,
+            priority=2122252543,
+            protocol="UDP",
+            type="host",
+            sdpMLineIndex=0,
+        )
+        await pc.addIceCandidate(candidate_with_index)
+
+    @asynctest
     async def test_addTrack_audio(self) -> None:
         pc = RTCPeerConnection()
 


### PR DESCRIPTION
while technically calling addIceCandidate before setRemoteDescription should not be allowed this can (and has) worked prior to #1318

Fixes #1332