### PR TITLE
Expand DTLS cipher list to support ECDHE-RSA and RSA ciphers for broader device compatibility

### DIFF
--- a/src/aiortc/rtcdtlstransport.py
+++ b/src/aiortc/rtcdtlstransport.py
@@ -201,7 +201,9 @@ class RTCCertificate:
         ctx.use_certificate(self._cert)
         ctx.use_privatekey(self._key)
         ctx.set_cipher_list(
-            b"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA"
+            b"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA:"
+            b"ECDHE-RSA-AES128-GCM-SHA256:ECDHE-RSA-CHACHA20-POLY1305:ECDHE-RSA-AES128-SHA:ECDHE-RSA-AES256-SHA:"
+            b"RSA-AES128-GCM-SHA256:RSA-AES128-SHA:RSA-AES256-SHA"
         )
         ctx.set_tlsext_use_srtp(b":".join(x.openssl_profile for x in srtp_profiles))
 


### PR DESCRIPTION
## Description

This PR expands the DTLS cipher list in `RTCCertificate` to include ECDHE-RSA and RSA ciphers, such as `TLS_ECDHE_RSA_WITH_AES_128_GCM_SHA256`. This improves compatibility with devices (e.g., ADC-V723 camera) and browsers that require these cipher suites.

Fixes #<issue-number>

## Type of change
- [ ] Bug fix
- [x] New feature
- [ ] Breaking change
- [ ] Documentation update
- [ ] Other (please describe):

## How Has This Been Tested?
<!-- Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. -->

- [x] Existing tests (all pass)
- [ ] New tests
- [x] Manual testing with ADC-V723 camera and Chrome

## Checklist
- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules

## Additional context

Expanded cipher list:
- ECDHE-ECDSA-AES128-GCM-SHA256
- ECDHE-ECDSA-CHACHA20-POLY1305
- ECDHE-ECDSA-AES128-SHA
- ECDHE-ECDSA-AES256-SHA
- ECDHE-RSA-AES128-GCM-SHA256
- ECDHE-RSA-CHACHA20-POLY1305
- ECDHE-RSA-AES128-SHA
- ECDHE-RSA-AES256-SHA
- RSA-AES128-GCM-SHA256
- RSA-AES128-SHA
- RSA-AES256-SHA

This enables DTLS negotiation with a wider range of devices and browsers.
