### PR TITLE
Add vp9

### DIFF
--- a/src/aiortc/codecs/__init__.py
+++ b/src/aiortc/codecs/__init__.py
@@ -14,7 +14,7 @@ from .g711 import PcmaDecoder, PcmaEncoder, PcmuDecoder, PcmuEncoder
 from .g722 import G722Decoder, G722Encoder
 from .h264 import H264Decoder, H264Encoder, h264_depayload
 from .opus import OpusDecoder, OpusEncoder
-from .vpx import Vp8Decoder, Vp8Encoder, vp8_depayload
+from .vpx import Vp8Decoder, Vp8Encoder, Vp9Decoder, Vp9Encoder, vp8_depayload, vp9_depayload
 
 # The clockrate for G.722 is 8kHz even though the sampling rate is 16kHz.
 # See https://datatracker.ietf.org/doc/html/rfc3551
@@ -93,6 +93,7 @@ def init_codecs() -> None:
         dynamic_pt += 2
 
     add_video_codec("video/VP8")
+    add_video_codec("video/VP9")
     for profile_level_id in ("42001f", "42e01f"):
         add_video_codec(
             "video/H264",
@@ -107,6 +108,8 @@ def init_codecs() -> None:
 def depayload(codec: RTCRtpCodecParameters, payload: bytes) -> bytes:
     if codec.name == "VP8":
         return vp8_depayload(payload)
+    elif codec.name == "VP9":
+        return vp9_depayload(payload)
     elif codec.name == "H264":
         return h264_depayload(payload)
     else:
@@ -160,6 +163,8 @@ def get_decoder(codec: RTCRtpCodecParameters) -> Decoder:
         return H264Decoder()
     elif mimeType == "video/vp8":
         return Vp8Decoder()
+    elif mimeType == "video/vp9":
+        return Vp9Decoder()
     else:
         raise ValueError(f"No decoder found for MIME type `{mimeType}`")
 
@@ -179,6 +184,8 @@ def get_encoder(codec: RTCRtpCodecParameters) -> Encoder:
         return H264Encoder()
     elif mimeType == "video/vp8":
         return Vp8Encoder()
+    elif mimeType == "video/vp9":
+        return Vp9Encoder()
     else:
         raise ValueError(f"No encoder found for MIME type `{mimeType}`")
 

--- a/src/aiortc/codecs/__init__.py
+++ b/src/aiortc/codecs/__init__.py
@@ -181,11 +181,11 @@ def get_encoder(codec: RTCRtpCodecParameters) -> Encoder:
     elif mimeType == "audio/pcmu":
         return PcmuEncoder()
     elif mimeType == "video/h264":
-        return H264Encoder()
+        return H264Encoder(codec_params=codec.codec_options)
     elif mimeType == "video/vp8":
-        return Vp8Encoder()
+        return Vp8Encoder(codec_params=codec.codec_options)
     elif mimeType == "video/vp9":
-        return Vp9Encoder()
+        return Vp9Encoder(codec_params=codec.codec_options)
     else:
         raise ValueError(f"No encoder found for MIME type `{mimeType}`")
 

--- a/src/aiortc/codecs/h264.py
+++ b/src/aiortc/codecs/h264.py
@@ -122,11 +122,12 @@ class H264Decoder(Decoder):
 
 
 class H264Encoder(Encoder):
-    def __init__(self) -> None:
+    def __init__(self, *, codec_params: Optional[dict] = None) -> None:
         self.buffer_data = b""
         self.buffer_pts: Optional[int] = None
         self.codec: Optional[VideoCodecContext] = None
         self.__target_bitrate = DEFAULT_BITRATE
+        self.codec_params = codec_params or {}
 
     @staticmethod
     def _packetize_fu_a(data: bytes) -> list[bytes]:
@@ -267,18 +268,29 @@ class H264Encoder(Encoder):
             frame.pict_type = av.video.frame.PictureType.NONE
 
         if self.codec is None:
-            self.codec = av.CodecContext.create("libx264", "w")
+            self.codec = av.CodecContext.create(
+                self.codec_params.get("codec", "libx264"),
+                "w",
+            )
             self.codec.width = frame.width
             self.codec.height = frame.height
             self.codec.bit_rate = self.target_bitrate
-            self.codec.pix_fmt = "yuv420p"
+            self.codec.pix_fmt = self.codec_params.get("pix_fmt", "yuv420p")
             self.codec.framerate = fractions.Fraction(MAX_FRAME_RATE, 1)
             self.codec.time_base = fractions.Fraction(1, MAX_FRAME_RATE)
             self.codec.options = {
                 "level": "31",
                 "tune": "zerolatency",
+            } | {
+                key: value
+                for key, value in self.codec_params.items()
+                if key not in [
+                    "codec", "pix_fmt", "profile", "number_of_threads",
+                ]
             }
-            self.codec.profile = "Baseline"
+            self.codec.profile = self.codec_params.get("profile", "Baseline")
+            if "number_of_threads" in self.codec_params:
+                self.codec.thread_count = self.codec_params["number_of_threads"]
 
         data_to_send = b""
         for package in self.codec.encode(frame):

--- a/src/aiortc/codecs/vpx.py
+++ b/src/aiortc/codecs/vpx.py
@@ -281,6 +281,125 @@ class Vp8Encoder(Encoder):
         return payloads
 
 
+class Vp9Decoder(Decoder):
+    def __init__(self) -> None:
+        self.codec = CodecContext.create("libvpx-vp9", "r")
+
+    def decode(self, encoded_frame: JitterFrame) -> list[Frame]:
+        try:
+            packet = Packet(encoded_frame.data)
+            packet.pts = encoded_frame.timestamp
+            packet.time_base = VIDEO_TIME_BASE
+            return cast(list[Frame], self.codec.decode(packet))
+        except av.FFmpegError as e:
+            logger.warning("Vp9Decoder() failed to decode, skipping package: " + str(e))
+            return []
+
+
+class Vp9Encoder(Encoder):
+    def __init__(self) -> None:
+        self.codec: Optional[VideoCodecContext] = None
+        self.picture_id = random.randint(0, (1 << 15) - 1)
+        self.__target_bitrate = DEFAULT_BITRATE
+
+    def encode(
+        self, frame: Frame, force_keyframe: bool = False
+    ) -> tuple[list[bytes], int]:
+        assert isinstance(frame, VideoFrame)
+        if frame.format.name != "yuv420p":
+            frame = frame.reformat(format="yuv420p")
+
+        if self.codec and (
+            frame.width != self.codec.width
+            or frame.height != self.codec.height
+            # We only adjust bitrate if it changes by over 10%.
+            or abs(self.target_bitrate - self.codec.bit_rate) / self.codec.bit_rate
+            > 0.1
+        ):
+            self.codec = None
+
+        # Force a complete image if a keyframe was requested.
+        if force_keyframe:
+            frame.pict_type = av.video.frame.PictureType.I
+
+        if self.codec is None:
+            self.codec = av.CodecContext.create("libvpx-vp9", "w")
+            self.codec.width = frame.width
+            self.codec.height = frame.height
+            self.codec.bit_rate = self.target_bitrate
+            self.codec.pix_fmt = "yuv420p"
+            self.codec.gop_size = 3000  # kf_max_dist
+            self.codec.qmin = 0  # rc_min_quantizer
+            self.codec.qmax = 63  # rc_max_quantizer
+            self.codec.options = {
+                # We want rc_buf_sz = 1000 and FFmpeg sets:
+                #   rc_buf_sz =  bufsize * 1000 / bit_rate
+                "bufsize": str(self.__target_bitrate),
+                "cpu-used": "1",
+                "deadline": "realtime",
+                "lag-in-frames": "0",
+                # Setting minrate = maxrate = bit_rate triggers CBR.
+                "minrate": str(self.target_bitrate),
+                "maxrate": str(self.target_bitrate),
+                "tile-columns": "0",  # log2 of number of tile columns (0 = 1 tile)
+                "tile-rows": "0",     # log2 of number of tile rows (0 = 1 tile)
+                "frame-parallel": "1",
+                "aq-mode": "0",       # adaptive quantization mode (0 = none)
+            }
+            self.codec.thread_count = number_of_threads(
+                frame.width * frame.height, multiprocessing.cpu_count()
+            )
+
+        data_to_send = b""
+        for package in self.codec.encode(frame):
+            data_to_send += bytes(package)
+
+        # Packetize.
+        payloads = self._packetize(data_to_send, self.picture_id)
+        timestamp = convert_timebase(frame.pts, frame.time_base, VIDEO_TIME_BASE)
+        self.picture_id = (self.picture_id + 1) % (1 << 15)
+        return payloads, timestamp
+
+    def pack(self, packet: Packet) -> tuple[list[bytes], int]:
+        payloads = self._packetize(bytes(packet), self.picture_id)
+        timestamp = convert_timebase(packet.pts, packet.time_base, VIDEO_TIME_BASE)
+        self.picture_id = (self.picture_id + 1) % (1 << 15)
+        return payloads, timestamp
+
+    @property
+    def target_bitrate(self) -> int:
+        """
+        Target bitrate in bits per second.
+        """
+        return self.__target_bitrate
+
+    @target_bitrate.setter
+    def target_bitrate(self, bitrate: int) -> None:
+        bitrate = max(MIN_BITRATE, min(bitrate, MAX_BITRATE))
+        self.__target_bitrate = bitrate
+
+    @classmethod
+    def _packetize(cls, buffer: bytes, picture_id: int) -> list[bytes]:
+        payloads = []
+        descr = VpxPayloadDescriptor(
+            partition_start=1, partition_id=0, picture_id=picture_id
+        )
+        length = len(buffer)
+        pos = 0
+        while pos < length:
+            descr_bytes = bytes(descr)
+            size = min(length - pos, PACKET_MAX - len(descr_bytes))
+            payloads.append(descr_bytes + buffer[pos : pos + size])
+            descr.partition_start = 0
+            pos += size
+        return payloads
+
+
 def vp8_depayload(payload: bytes) -> bytes:
+    descriptor, data = VpxPayloadDescriptor.parse(payload)
+    return data
+
+
+def vp9_depayload(payload: bytes) -> bytes:
     descriptor, data = VpxPayloadDescriptor.parse(payload)
     return data

--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -65,6 +65,9 @@ def filter_preferred_codecs(
                 codec.mimeType.lower() == pref.mimeType.lower()
                 and codec.parameters == pref.parameters
             ):
+                # Copy codec_options from capability to parameters
+                if hasattr(pref, 'codec_options') and pref.codec_options:
+                    codec.codec_options = pref.codec_options.copy()
                 filtered.append(codec)
 
                 # add corresponding RTX

--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -65,9 +65,6 @@ def filter_preferred_codecs(
                 codec.mimeType.lower() == pref.mimeType.lower()
                 and codec.parameters == pref.parameters
             ):
-                # Copy codec_options from capability to parameters
-                if hasattr(pref, 'codec_options') and pref.codec_options:
-                    codec.codec_options = pref.codec_options.copy()
                 filtered.append(codec)
 
                 # add corresponding RTX

--- a/src/aiortc/rtcrtpparameters.py
+++ b/src/aiortc/rtcrtpparameters.py
@@ -46,6 +46,8 @@ class RTCRtpCodecParameters:
     "Transport layer and codec-specific feedback messages for this codec."
     parameters: ParametersDict = field(default_factory=dict)
     "Codec-specific parameters available for signaling."
+    codec_options: ParametersDict = field(default_factory=dict)
+    "Internal encoder configuration options (not signaled to remote peer)."
 
     @property
     def name(self) -> str:

--- a/src/aiortc/rtcrtpparameters.py
+++ b/src/aiortc/rtcrtpparameters.py
@@ -19,6 +19,8 @@ class RTCRtpCodecCapability:
     "The number of channels supported (e.g. two for stereo)."
     parameters: ParametersDict = field(default_factory=dict)
     "Codec-specific parameters available for signaling."
+    codec_options: ParametersDict = field(default_factory=dict)
+    "Internal encoder configuration options (not signaled to remote peer)."
 
     @property
     def name(self) -> str:

--- a/src/aiortc/rtcrtptransceiver.py
+++ b/src/aiortc/rtcrtptransceiver.py
@@ -114,9 +114,12 @@ class RTCRtpTransceiver:
         capabilities = get_capabilities(self.kind).codecs
         unique: list[RTCRtpCodecCapability] = []
         for codec in reversed(codecs):
-            if codec not in capabilities:
-                raise ValueError("Codec is not in capabilities")
-            if codec not in unique:
+            from copy import deepcopy
+            codec_no_options = deepcopy(codec)
+            codec_no_options.codec_options = {}
+            if codec_no_options not in capabilities:
+                raise ValueError(f"Codec {codec_no_options} is not in capabilities {capabilities}")
+            if codec_no_options not in unique:
                 unique.insert(0, codec)
         self._preferred_codecs = unique
 


### PR DESCRIPTION
Thanks for the cool software.

I'm trying to experiment with different target bitrates and codecs.

I still can't get VP9 or H264 to work on any browser of mine, but even https://mozilla.github.io/webrtc-landing/pc_test.html show that forcing H264 doesn't seem to work...

I generally think that you'll have many people trying to tweak parameters like this, and the ability to adjust things without digging so far down the chain will be helpful. Let me know what you think I can split the PR however you wish.