### PR TITLE
add support for RTCConfiguration.alwaysNegotiateDataChannels

### DIFF
--- a/src/aiortc/rtcconfiguration.py
+++ b/src/aiortc/rtcconfiguration.py
@@ -64,3 +64,6 @@ class RTCConfiguration:
 
     bundlePolicy: RTCBundlePolicy = RTCBundlePolicy.BALANCED
     "The media-bundling policy to use when gathering ICE candidates."
+
+    alwaysNegotiateDataChannels: bool = False
+    "Whether to always negotiate data channels in the SDP."


### PR DESCRIPTION
which always negotiates datachannels and puts them first in the SDP. Spec:
  https://w3c.github.io/webrtc-extensions/#always-negotiating-datachannels