### PR TITLE
Support parsing SDP `rtcp` attribute without host

### DIFF
--- a/src/aiortc/sdp.py
+++ b/src/aiortc/sdp.py
@@ -301,8 +301,11 @@ class MediaDescription:
         if self.msid:
             lines.append(f"a=msid:{self.msid}")
 
-        if self.rtcp_port is not None and self.rtcp_host is not None:
-            lines.append(f"a=rtcp:{self.rtcp_port} {ipaddress_to_sdp(self.rtcp_host)}")
+        if self.rtcp_port is not None:
+            line = f"a=rtcp:{self.rtcp_port}"
+            if self.rtcp_host is not None:
+                line += f" {ipaddress_to_sdp(self.rtcp_host)}"
+            lines.append(line)
             if self.rtcp_mux:
                 lines.append("a=rtcp-mux")
 
@@ -487,9 +490,10 @@ class SessionDescription:
                     elif attr == "msid":
                         current_media.msid = value
                     elif attr == "rtcp":
-                        port, rest = value.split(" ", 1)
-                        current_media.rtcp_port = int(port)
-                        current_media.rtcp_host = ipaddress_from_sdp(rest)
+                        bits = value.split(" ", 1)
+                        current_media.rtcp_port = int(bits[0])
+                        if len(bits) > 1:
+                            current_media.rtcp_host = ipaddress_from_sdp(bits[1])
                     elif attr == "rtcp-mux":
                         current_media.rtcp_mux = True
                     elif attr == "setup":

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -1039,6 +1039,82 @@ a=setup:actpass
             ),
         )
 
+    def test_audio_rtcp_without_port(self) -> None:
+        d = SessionDescription.parse(
+            lf2crlf(
+                """v=0
+o=- 863426017819471768 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+m=audio 43580 RTP/AVP 0
+c=IN IP4 192.168.99.58
+a=sendrecv
+a=rtcp:9
+a=rtpmap:0 PCMU/8000
+"""
+            )
+        )
+
+        self.assertEqual(d.group, [])
+        self.assertEqual(d.msid_semantic, [])
+        self.assertEqual(d.host, None)
+        self.assertEqual(d.name, "-")
+        self.assertEqual(d.origin, "- 863426017819471768 2 IN IP4 127.0.0.1")
+        self.assertEqual(d.time, "0 0")
+        self.assertEqual(d.version, 0)
+
+        self.assertEqual(len(d.media), 1)
+        self.assertEqual(d.media[0].kind, "audio")
+        self.assertEqual(d.media[0].host, "192.168.99.58")
+        self.assertEqual(d.media[0].port, 43580)
+        self.assertEqual(d.media[0].profile, "RTP/AVP")
+        self.assertEqual(d.media[0].direction, "sendrecv")
+        self.assertEqual(d.media[0].msid, None)
+        self.assertEqual(
+            d.media[0].rtp.codecs,
+            [
+                RTCRtpCodecParameters(
+                    mimeType="audio/PCMU", clockRate=8000, channels=1, payloadType=0
+                ),
+            ],
+        )
+        self.assertEqual(d.media[0].rtp.headerExtensions, [])
+        self.assertEqual(d.media[0].rtp.muxId, "")
+        self.assertEqual(d.media[0].rtcp_host, None)
+        self.assertEqual(d.media[0].rtcp_port, 9)
+        self.assertEqual(d.media[0].rtcp_mux, False)
+
+        # ssrc
+        self.assertEqual(d.media[0].ssrc, [])
+        self.assertEqual(d.media[0].ssrc_group, [])
+
+        # formats
+        self.assertEqual(d.media[0].fmt, [0])
+        self.assertEqual(d.media[0].sctpmap, {})
+        self.assertEqual(d.media[0].sctp_port, None)
+
+        # ice
+        self.assertEqual(len(d.media[0].ice_candidates), 0)
+
+        # dtls
+        self.assertEqual(d.media[0].dtls, None)
+
+        self.assertEqual(
+            str(d),
+            lf2crlf(
+                """v=0
+o=- 863426017819471768 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+m=audio 43580 RTP/AVP 0
+c=IN IP4 192.168.99.58
+a=sendrecv
+a=rtcp:9
+a=rtpmap:0 PCMU/8000
+"""
+            ),
+        )
+
     def test_datachannel_firefox(self) -> None:
         d = SessionDescription.parse(
             lf2crlf(


### PR DESCRIPTION
Fixes: #1368