### PR TITLE
Use "UDP/DTLS/SCTP" by default in our SDP for data channels

### DIFF
--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -306,7 +306,9 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         self.__seenMids: set[str] = set()
         self.__sctp: Optional[RTCSctpTransport] = None
         self.__sctp_mline_index: Optional[int] = None
-        self._sctpLegacySdp = True
+        # By default we use "UDP/DTLS/SCTP" in our SDP, but we also
+        # accept "DTLS/SCTP" from older browsers.
+        self._sctpLegacySdp = False
         self.__sctpRemotePort: Optional[int] = None
         self.__sctpRemoteCaps: Optional[RTCSctpCapabilities] = None
         self.__stream_id = str(uuid.uuid4())


### PR DESCRIPTION
We have long supported the "UDP/DTLS/SCTP" SDP form for negotiating data channels, but continued sending our offers as the legacy "DTLS/SCTP" form. Use the modern form going forward, while retaining compatibility for offers received in the legacy format.

Fixes: #1338