### PR TITLE
additional cipher suite for gstreamer webrtc server

### DIFF
--- a/src/aiortc/rtcdtlstransport.py
+++ b/src/aiortc/rtcdtlstransport.py
@@ -201,7 +201,7 @@ class RTCCertificate:
         ctx.use_certificate(self._cert)
         ctx.use_privatekey(self._key)
         ctx.set_cipher_list(
-            b"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA"
+            b"ECDHE-ECDSA-AES128-GCM-SHA256:ECDHE-ECDSA-CHACHA20-POLY1305:ECDHE-ECDSA-AES128-SHA:ECDHE-ECDSA-AES256-SHA:ECDHE-RSA-AES128-GCM-SHA256"
         )
         ctx.set_tlsext_use_srtp(b":".join(x.openssl_profile for x in srtp_profiles))
 


### PR DESCRIPTION
Using aiortc as client for the gstreamer webrtc component leads to the following error:

```
0:00:19.629139112  3949   0x7f1c003510 ERROR         dtlsconnection gstdtlsconnection.c:994:handle_error:<dtlsconnection0> Fatal SSL error
0:00:19.629283927  3949   0x7f1c003510 ERROR         dtlsconnection gstdtlsconnection.c:977:ssl_err_cb:<dtlsconnection0> ssl error: 60F1F9047F000000:error:0A0000C1:SSL routines:tls_post_process_client_hello:no shared cipher:../ssl/statem/statem_srvr.c:2333:

0:00:19.629456576  3949   0x7f1c003510 ERROR                dtlsdec gstdtlsdec.c:503:process_buffer:<dtlsdec0> Error processing buffer: Fatal SSL error
```

adding ECDHE-RSA-AES128-GCM-SHA256 to the cipher list fixes the issue.