### PR TITLE
Wait for event handlers completion on datachannel open

### DIFF
--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -1152,8 +1152,9 @@ class RTCPeerConnection(AsyncIOEventEmitter):
         self.__sctp.mid = None
 
         @self.__sctp.on("datachannel")
-        def on_datachannel(channel: RTCDataChannel) -> None:
+        async def on_datachannel(channel: RTCDataChannel) -> None:
             self.emit("datachannel", channel)
+            await self.wait_for_complete()
 
     def __createTransceiver(
         self, direction: str, kind: str, sender_track: Optional[MediaStreamTrack] = None

--- a/src/aiortc/rtcsctptransport.py
+++ b/src/aiortc/rtcsctptransport.py
@@ -1788,6 +1788,7 @@ class RTCSctpTransport(AsyncIOEventEmitter):
 
                 # emit channel
                 self.emit("datachannel", channel)
+                await self.wait_for_complete()
             elif msg_type == DATA_CHANNEL_ACK:
                 assert stream_id in self._data_channels
                 channel = self._data_channels[stream_id]


### PR DESCRIPTION
When opening a datachannel, the event handler is supposed to use the channel reference to add handlers for channel events. However, if the datachannel open event handler is an async function, its execution is delayed and events could be lost if they happen in the meantime.

We encountered this issue since the application on the other side tried to open multiple channels and immediately started sending messages. While the issue didn't always happen, if a message was sent before having the coroutine handler for the `datachannel` event executed that message would effectively be lost. Waiting for the event handler completion ensures that we can register the channel event handlers.