### PR TITLE
sdp: handle missing a=msid-semantic: line

### DIFF
--- a/src/aiortc/sdp.py
+++ b/src/aiortc/sdp.py
@@ -567,7 +567,11 @@ class SessionDescription:
         assert media in self.media
         if media.msid is not None and " " in media.msid:
             bits = media.msid.split()
-            for group in self.msid_semantic:
+            msid_semantic = self.msid_semantic
+            if not msid_semantic:
+                # assume "WMS *" for backward compat.
+                msid_semantic = [GroupDescription(semantic="WMS", items=["*"])]
+            for group in msid_semantic:
                 if group.semantic == "WMS" and (
                     bits[0] in group.items or "*" in group.items
                 ):

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -592,6 +592,32 @@ a=setup:active
             ),
         )
 
+    def test_no_msid_semantic(self) -> None:
+        d = SessionDescription.parse(
+            lf2crlf(
+                """v=0
+o=- 863426017819471768 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0
+m=audio 16628 UDP/TLS/RTP/SAVPF 8
+a=rtpmap:8 PCMA/8000
+a=fingerprint:sha-256 35:5A:BC:8E:CD:F8:CD:EB:36:00:BB:C4:C3:33:54:B5:9B:70:3C:E9:C4:33:8F:39:3C:4B:5B:5C:AD:88:12:2B
+a=setup:active
+a=rtcp-mux
+a=rtcp:16628 IN IP4 1.2.3.4
+a=ice-ufrag:75EDuLTEOkEUd3cu
+a=ice-pwd:5dvb9SbfooWc49814CupdeTS
+a=candidate:0560693492 1 udp 659136 1.2.3.4 16628 typ host generation 0
+a=end-of-candidates
+a=msid:stream deprecatedtrack
+"""
+            )
+        )
+
+        self.assertEqual(d.media[0].msid, "stream deprecatedtrack")
+        self.assertEqual(d.webrtc_track_id(d.media[0]), "deprecatedtrack")
+
     def test_audio_freeswitch_no_dtls(self) -> None:
         d = SessionDescription.parse(
             lf2crlf(

--- a/tests/test_sdp.py
+++ b/tests/test_sdp.py
@@ -617,6 +617,7 @@ a=msid:stream deprecatedtrack
 
         self.assertEqual(d.media[0].msid, "stream deprecatedtrack")
         self.assertEqual(d.webrtc_track_id(d.media[0]), "deprecatedtrack")
+        self.assertFalse("a=msid-semantic:" in str(d))
 
     def test_audio_freeswitch_no_dtls(self) -> None:
         d = SessionDescription.parse(


### PR DESCRIPTION
which is a thing of the past despite still being sent by browsers in various different forms. If not present, assume wildcard semantics.

Fixes #1395