### PR TITLE
Fix for different ice-ufrag/pwd's in sdp

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.14",
 ]
 dependencies = [
-    "aioice>=0.10.1,<1.0.0",
+    "aioice>=0.10.2,<1.0.0",
     "av>=14.0.0,<17.0.0",
     "cryptography>=44.0.0",
     "google-crc32c>=1.1",

--- a/src/aiortc/rtcicetransport.py
+++ b/src/aiortc/rtcicetransport.py
@@ -193,7 +193,12 @@ class RTCIceGatherer(AsyncIOEventEmitter):
             iceServers = self.getDefaultIceServers()
         ice_kwargs = connection_kwargs(iceServers)
 
-        self._connection = Connection(ice_controlling=False, **ice_kwargs)
+        self._connection = Connection(
+            ice_controlling=False,
+            local_username=local_username,
+            local_password=local_password,
+            **ice_kwargs,
+        )
         self._remote_candidates_end = False
         self.__state = "new"
 

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -5377,6 +5377,11 @@ a=rtpmap:0 PCMU/8000
         self.assertEqual(param1.password, param2.password)
         self.assertEqual(transceiver.receiver.transport, pc.sctp.transport)
 
+        self.assertEqual(
+            transceiver.receiver.transport.transport.iceGatherer.getLocalParameters(),
+            pc.sctp.transport.transport.iceGatherer.getLocalParameters(),
+        )
+
     @asynctest
     async def test_bundlepolicy_transports_balanced(self) -> None:
         pc = RTCPeerConnection(RTCConfiguration(bundlePolicy=RTCBundlePolicy.BALANCED))
@@ -5392,6 +5397,19 @@ a=rtpmap:0 PCMU/8000
         )
         self.assertNotEqual(transceiver1.receiver.transport, pc.sctp.transport)
         self.assertNotEqual(transceiver2.receiver.transport, pc.sctp.transport)
+
+        self.assertEqual(
+            transceiver1.receiver.transport.transport.iceGatherer.getLocalParameters(),
+            transceiver2.receiver.transport.transport.iceGatherer.getLocalParameters(),
+        )
+        self.assertEqual(
+            transceiver1.receiver.transport.transport.iceGatherer.getLocalParameters(),
+            transceiver3.receiver.transport.transport.iceGatherer.getLocalParameters(),
+        )
+        self.assertEqual(
+            transceiver1.receiver.transport.transport.iceGatherer.getLocalParameters(),
+            pc.sctp.transport.transport.iceGatherer.getLocalParameters(),
+        )
 
     @asynctest
     async def test_bundlepolicy_transports_max_compat(self) -> None:
@@ -5411,6 +5429,19 @@ a=rtpmap:0 PCMU/8000
         self.assertNotEqual(transceiver1.receiver.transport, pc.sctp.transport)
         self.assertNotEqual(transceiver2.receiver.transport, pc.sctp.transport)
 
+        self.assertEqual(
+            transceiver1.receiver.transport.transport.iceGatherer.getLocalParameters(),
+            transceiver2.receiver.transport.transport.iceGatherer.getLocalParameters(),
+        )
+        self.assertEqual(
+            transceiver1.receiver.transport.transport.iceGatherer.getLocalParameters(),
+            transceiver3.receiver.transport.transport.iceGatherer.getLocalParameters(),
+        )
+        self.assertEqual(
+            transceiver1.receiver.transport.transport.iceGatherer.getLocalParameters(),
+            pc.sctp.transport.transport.iceGatherer.getLocalParameters(),
+        )
+
     @asynctest
     async def test_bundlepolicy_transports_max_bundle(self) -> None:
         pc = RTCPeerConnection(
@@ -5427,3 +5458,16 @@ a=rtpmap:0 PCMU/8000
             transceiver1.receiver.transport, transceiver3.receiver.transport
         )
         self.assertEqual(transceiver1.receiver.transport, pc.sctp.transport)
+
+        self.assertEqual(
+            transceiver1.receiver.transport.transport.iceGatherer.getLocalParameters(),
+            transceiver2.receiver.transport.transport.iceGatherer.getLocalParameters(),
+        )
+        self.assertEqual(
+            transceiver1.receiver.transport.transport.iceGatherer.getLocalParameters(),
+            transceiver3.receiver.transport.transport.iceGatherer.getLocalParameters(),
+        )
+        self.assertEqual(
+            transceiver1.receiver.transport.transport.iceGatherer.getLocalParameters(),
+            pc.sctp.transport.transport.iceGatherer.getLocalParameters(),
+        )


### PR DESCRIPTION
This PR fixes #370

As far as I understand RFCs, all `ice-ufrag/ice-pws` in different sections of single offer/answer sdp should have same values. At least this behaviour is expected by pion. 

Current aiortc code has intention to support sharing same credentials by copying those from existing ICE gatherer: 
https://github.com/aiortc/aiortc/blob/156db1488af18d07a742dd2db68465f366765537/src/aiortc/rtcpeerconnection.py#L1103-L1120

But unfortunately, lines added in this PR seems to be forgotten and `local_username`/`local_password` are not used in the RTCIceGatherer init. So let's fix this!

One thing to note, is that there's an unfortunate problem with underlying aioice implementation, which would not accept providing credentials with uppercase letters (even though it would generate such credentials itself). So current PR depends on aioice accepting [this PR](https://github.com/aiortc/aioice/pull/103)