### PR TITLE
Fix payload type collision in codec negotiation

### DIFF
--- a/src/aiortc/rtcrtptransceiver.py
+++ b/src/aiortc/rtcrtptransceiver.py
@@ -105,11 +105,12 @@ class RTCRtpTransceiver:
         See :meth:`RTCRtpSender.getCapabilities` and
         :meth:`RTCRtpReceiver.getCapabilities` for the supported codecs.
 
-        :param codecs: A list of :class:`RTCRtpCodecCapability`, in decreasing order
-                        of preference. If empty, restores the default preferences.
+        :param codecs: A list of :class:`RTCRtpCodecCapability` in decreasing order
+                       of preference. If empty, restores the default preferences.
         """
         if not codecs:
             self._preferred_codecs = []
+            return
 
         capabilities = get_capabilities(self.kind).codecs
         unique: list[RTCRtpCodecCapability] = []

--- a/src/aiortc/rtcrtptransceiver.py
+++ b/src/aiortc/rtcrtptransceiver.py
@@ -105,12 +105,11 @@ class RTCRtpTransceiver:
         See :meth:`RTCRtpSender.getCapabilities` and
         :meth:`RTCRtpReceiver.getCapabilities` for the supported codecs.
 
-        :param codecs: A list of :class:`RTCRtpCodecCapability` in decreasing order
-                       of preference. If empty, restores the default preferences.
+        :param codecs: A list of :class:`RTCRtpCodecCapability`, in decreasing order
+                        of preference. If empty, restores the default preferences.
         """
         if not codecs:
             self._preferred_codecs = []
-            return
 
         capabilities = get_capabilities(self.kind).codecs
         unique: list[RTCRtpCodecCapability] = []

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -688,6 +688,115 @@ class RTCRtpCodecParametersTest(TestCase):
         self.assertIn(127, used_payload_types)  # video
         self.assertEqual(len(used_payload_types), 2)
 
+    def test_find_common_codecs_without_fix_would_fail(self) -> None:
+        """
+        Verify that the old implementation (without PT collision fix) would
+        produce duplicate PTs. This test documents the bug that was fixed.
+
+        The old find_common_codecs() blindly copied remote PTs without collision
+        detection, causing duplicate assignments when remote SDP had conflicting PTs.
+        """
+        import copy
+
+        # This is the OLD implementation without the fix - it will produce duplicates
+        def find_common_codecs_old(
+            local_codecs: list[RTCRtpCodecParameters],
+            remote_codecs: list[RTCRtpCodecParameters],
+        ) -> list[RTCRtpCodecParameters]:
+            """Old implementation that has the PT collision bug."""
+            from aiortc.codecs import is_rtx
+            from aiortc.rtp import DYNAMIC_PAYLOAD_TYPES
+
+            common = []
+            common_base: dict[int, RTCRtpCodecParameters] = {}
+            for c in remote_codecs:
+                if is_rtx(c):
+                    apt = c.parameters.get("apt")
+                    if isinstance(apt, int) and apt in common_base:
+                        base = common_base[apt]
+                        if c.clockRate == base.clockRate:
+                            common.append(copy.deepcopy(c))
+                    continue
+
+                for codec in local_codecs:
+                    if is_codec_compatible(codec, c):
+                        codec = copy.deepcopy(codec)
+                        if c.payloadType in DYNAMIC_PAYLOAD_TYPES:
+                            codec.payloadType = c.payloadType  # BUG: no collision check!
+                        codec.rtcpFeedback = list(
+                            filter(lambda x: x in c.rtcpFeedback, codec.rtcpFeedback)
+                        )
+                        common.append(codec)
+                        common_base[codec.payloadType] = codec
+                        break
+            return common
+
+        local_codecs = [
+            RTCRtpCodecParameters(
+                mimeType="video/H264",
+                clockRate=90000,
+                payloadType=101,
+                parameters={"profile-level-id": "42e01f"},
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/rtx",
+                clockRate=90000,
+                payloadType=102,
+                parameters={"apt": 101},
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/VP8", clockRate=90000, payloadType=97
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/rtx",
+                clockRate=90000,
+                payloadType=98,
+                parameters={"apt": 97},
+            ),
+        ]
+
+        # Remote SDP with collision: H264 RTX and VP8 both at PT 103
+        remote_codecs = [
+            RTCRtpCodecParameters(
+                mimeType="video/H264",
+                clockRate=90000,
+                payloadType=102,
+                parameters={"profile-level-id": "42e01f"},
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/rtx",
+                clockRate=90000,
+                payloadType=103,  # RTX for H264
+                parameters={"apt": 102},
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/VP8", clockRate=90000, payloadType=103  # COLLISION!
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/rtx",
+                clockRate=90000,
+                payloadType=104,
+                parameters={"apt": 103},
+            ),
+        ]
+
+        # OLD implementation produces duplicate PTs (the bug!)
+        common_old = find_common_codecs_old(local_codecs, remote_codecs)
+        pts_old = [c.payloadType for c in common_old]
+        # Verify the bug exists: duplicate PTs
+        self.assertNotEqual(
+            len(pts_old), len(set(pts_old)),
+            f"Old implementation should have duplicate PTs but got unique: {pts_old}"
+        )
+
+        # NEW implementation (with fix) produces unique PTs
+        common_new = find_common_codecs(local_codecs, remote_codecs)
+        pts_new = [c.payloadType for c in common_new]
+        self.assertEqual(
+            len(pts_new), len(set(pts_new)),
+            f"New implementation should have unique PTs but got duplicates: {pts_new}"
+        )
+
 
 class RTCPeerConnectionTest(TestCase):
     def assertBundled(self, pc: RTCPeerConnection) -> None:
@@ -5144,6 +5253,93 @@ a=rtpmap:0 PCMU/8000
         self.assertEqual(
             str(cm.exception),
             'Cannot handle offer in signaling state "have-local-offer"',
+        )
+
+        # close
+        await pc.close()
+
+    @asynctest
+    async def test_setRemoteDescription_pt_collision_in_offer(self) -> None:
+        """
+        End-to-end test for PT collision fix (PR #1390).
+
+        Simulates a browser SDP offer where H264 RTX uses PT 103 and VP8 also
+        uses PT 103 (collision). The fix ensures aiortc creates an answer with
+        unique PTs by reassigning the colliding PT.
+
+        Without the fix, this would create an answer with duplicate PTs, which
+        browsers reject with: "Duplicate payload type with conflicting codec
+        name or clock rate"
+        """
+        import re
+
+        # Create a realistic browser-like SDP offer with PT collision
+        # H264 at PT 102, H264 RTX at PT 103, VP8 at PT 103 (collision!)
+        problematic_sdp = lf2crlf(
+            """v=0
+o=- 1234567890 2 IN IP4 127.0.0.1
+s=-
+t=0 0
+a=group:BUNDLE 0
+a=msid-semantic: WMS stream
+m=video 9 UDP/TLS/RTP/SAVPF 102 103 103 104
+c=IN IP4 0.0.0.0
+a=rtcp:9 IN IP4 0.0.0.0
+a=ice-ufrag:testufrag
+a=ice-pwd:testpwdtestpwdtestpwdtest
+a=ice-options:trickle
+a=fingerprint:sha-256 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
+a=setup:actpass
+a=mid:0
+a=sendrecv
+a=rtcp-mux
+a=rtpmap:102 H264/90000
+a=rtcp-fb:102 nack
+a=rtcp-fb:102 nack pli
+a=rtcp-fb:102 goog-remb
+a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
+a=rtpmap:103 rtx/90000
+a=fmtp:103 apt=102
+a=rtpmap:103 VP8/90000
+a=rtcp-fb:103 nack
+a=rtcp-fb:103 nack pli
+a=rtcp-fb:103 goog-remb
+a=rtpmap:104 rtx/90000
+a=fmtp:104 apt=103
+a=ssrc:1111111111 cname:testcname
+"""
+        )
+
+        pc = RTCPeerConnection()
+
+        # Set the problematic offer as remote description
+        await pc.setRemoteDescription(
+            RTCSessionDescription(sdp=problematic_sdp, type="offer")
+        )
+
+        # Create answer
+        answer = await pc.createAnswer()
+        await pc.setLocalDescription(answer)
+
+        # Parse the answer SDP and extract all payload types
+        pts_in_answer = []
+        for line in answer.sdp.split("\r\n"):
+            # Match rtpmap lines: a=rtpmap:PT codec/clockrate
+            match = re.match(r"a=rtpmap:(\d+)\s+", line)
+            if match:
+                pts_in_answer.append(int(match.group(1)))
+
+        # Verify all PTs in answer are unique (no duplicates)
+        self.assertEqual(
+            len(pts_in_answer),
+            len(set(pts_in_answer)),
+            f"Answer SDP has duplicate payload types! PTs: {pts_in_answer}\n"
+            f"Answer SDP:\n{answer.sdp}",
+        )
+
+        # Verify we have the expected codecs (H264, RTX, VP8, RTX)
+        self.assertGreaterEqual(
+            len(pts_in_answer), 2, "Answer should have at least 2 codecs"
         )
 
         # close

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -688,115 +688,6 @@ class RTCRtpCodecParametersTest(TestCase):
         self.assertIn(127, used_payload_types)  # video
         self.assertEqual(len(used_payload_types), 2)
 
-    def test_find_common_codecs_without_fix_would_fail(self) -> None:
-        """
-        Verify that the old implementation (without PT collision fix) would
-        produce duplicate PTs. This test documents the bug that was fixed.
-
-        The old find_common_codecs() blindly copied remote PTs without collision
-        detection, causing duplicate assignments when remote SDP had conflicting PTs.
-        """
-        import copy
-
-        # This is the OLD implementation without the fix - it will produce duplicates
-        def find_common_codecs_old(
-            local_codecs: list[RTCRtpCodecParameters],
-            remote_codecs: list[RTCRtpCodecParameters],
-        ) -> list[RTCRtpCodecParameters]:
-            """Old implementation that has the PT collision bug."""
-            from aiortc.codecs import is_rtx
-            from aiortc.rtp import DYNAMIC_PAYLOAD_TYPES
-
-            common = []
-            common_base: dict[int, RTCRtpCodecParameters] = {}
-            for c in remote_codecs:
-                if is_rtx(c):
-                    apt = c.parameters.get("apt")
-                    if isinstance(apt, int) and apt in common_base:
-                        base = common_base[apt]
-                        if c.clockRate == base.clockRate:
-                            common.append(copy.deepcopy(c))
-                    continue
-
-                for codec in local_codecs:
-                    if is_codec_compatible(codec, c):
-                        codec = copy.deepcopy(codec)
-                        if c.payloadType in DYNAMIC_PAYLOAD_TYPES:
-                            codec.payloadType = c.payloadType  # BUG: no collision check!
-                        codec.rtcpFeedback = list(
-                            filter(lambda x: x in c.rtcpFeedback, codec.rtcpFeedback)
-                        )
-                        common.append(codec)
-                        common_base[codec.payloadType] = codec
-                        break
-            return common
-
-        local_codecs = [
-            RTCRtpCodecParameters(
-                mimeType="video/H264",
-                clockRate=90000,
-                payloadType=101,
-                parameters={"profile-level-id": "42e01f"},
-            ),
-            RTCRtpCodecParameters(
-                mimeType="video/rtx",
-                clockRate=90000,
-                payloadType=102,
-                parameters={"apt": 101},
-            ),
-            RTCRtpCodecParameters(
-                mimeType="video/VP8", clockRate=90000, payloadType=97
-            ),
-            RTCRtpCodecParameters(
-                mimeType="video/rtx",
-                clockRate=90000,
-                payloadType=98,
-                parameters={"apt": 97},
-            ),
-        ]
-
-        # Remote SDP with collision: H264 RTX and VP8 both at PT 103
-        remote_codecs = [
-            RTCRtpCodecParameters(
-                mimeType="video/H264",
-                clockRate=90000,
-                payloadType=102,
-                parameters={"profile-level-id": "42e01f"},
-            ),
-            RTCRtpCodecParameters(
-                mimeType="video/rtx",
-                clockRate=90000,
-                payloadType=103,  # RTX for H264
-                parameters={"apt": 102},
-            ),
-            RTCRtpCodecParameters(
-                mimeType="video/VP8", clockRate=90000, payloadType=103  # COLLISION!
-            ),
-            RTCRtpCodecParameters(
-                mimeType="video/rtx",
-                clockRate=90000,
-                payloadType=104,
-                parameters={"apt": 103},
-            ),
-        ]
-
-        # OLD implementation produces duplicate PTs (the bug!)
-        common_old = find_common_codecs_old(local_codecs, remote_codecs)
-        pts_old = [c.payloadType for c in common_old]
-        # Verify the bug exists: duplicate PTs
-        self.assertNotEqual(
-            len(pts_old), len(set(pts_old)),
-            f"Old implementation should have duplicate PTs but got unique: {pts_old}"
-        )
-
-        # NEW implementation (with fix) produces unique PTs
-        common_new = find_common_codecs(local_codecs, remote_codecs)
-        pts_new = [c.payloadType for c in common_new]
-        self.assertEqual(
-            len(pts_new), len(set(pts_new)),
-            f"New implementation should have unique PTs but got duplicates: {pts_new}"
-        )
-
 
 class RTCPeerConnectionTest(TestCase):
     def assertBundled(self, pc: RTCPeerConnection) -> None:
@@ -5261,20 +5152,9 @@ a=rtpmap:0 PCMU/8000
     @asynctest
     async def test_setRemoteDescription_pt_collision_in_offer(self) -> None:
         """
-        End-to-end test for PT collision fix (PR #1390).
-
-        Simulates a browser SDP offer where H264 RTX uses PT 103 and VP8 also
-        uses PT 103 (collision). The fix ensures aiortc creates an answer with
-        unique PTs by reassigning the colliding PT.
-
-        Without the fix, this would create an answer with duplicate PTs, which
-        browsers reject with: "Duplicate payload type with conflicting codec
-        name or clock rate"
+        Test PT collision fix: H264 RTX and VP8 both at PT 103 in remote offer.
         """
-        import re
-
-        # Create a realistic browser-like SDP offer with PT collision
-        # H264 at PT 102, H264 RTX at PT 103, VP8 at PT 103 (collision!)
+        # SDP with collision: H264 at PT 102, H264 RTX at PT 103, VP8 at PT 103
         problematic_sdp = lf2crlf(
             """v=0
 o=- 1234567890 2 IN IP4 127.0.0.1
@@ -5321,26 +5201,13 @@ a=ssrc:1111111111 cname:testcname
         answer = await pc.createAnswer()
         await pc.setLocalDescription(answer)
 
-        # Parse the answer SDP and extract all payload types
-        pts_in_answer = []
-        for line in answer.sdp.split("\r\n"):
-            # Match rtpmap lines: a=rtpmap:PT codec/clockrate
-            match = re.match(r"a=rtpmap:(\d+)\s+", line)
-            if match:
-                pts_in_answer.append(int(match.group(1)))
+        # Extract payload types from answer SDP
+        pts_in_answer = re.findall(r"a=rtpmap:(\d+)\s+", answer.sdp)
+        pts_in_answer = [int(pt) for pt in pts_in_answer]
 
-        # Verify all PTs in answer are unique (no duplicates)
-        self.assertEqual(
-            len(pts_in_answer),
-            len(set(pts_in_answer)),
-            f"Answer SDP has duplicate payload types! PTs: {pts_in_answer}\n"
-            f"Answer SDP:\n{answer.sdp}",
-        )
-
-        # Verify we have the expected codecs (H264, RTX, VP8, RTX)
-        self.assertGreaterEqual(
-            len(pts_in_answer), 2, "Answer should have at least 2 codecs"
-        )
+        # Verify all PTs are unique (no collisions)
+        self.assertEqual(len(pts_in_answer), len(set(pts_in_answer)))
+        self.assertGreaterEqual(len(pts_in_answer), 2)
 
         # close
         await pc.close()

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -501,6 +501,193 @@ class RTCRtpCodecParametersTest(TestCase):
             )
         )
 
+    def test_find_common_codecs_pt_collision_pr1390(self) -> None:
+        """
+        Test PT collision fix for PR #1390.
+        Remote has H264 RTX at PT 103, then VP9 main also at PT 103.
+        """
+        local_codecs = [
+            RTCRtpCodecParameters(
+                mimeType="video/H264",
+                clockRate=90000,
+                payloadType=101,
+                parameters={"profile-level-id": "42e01f"},
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/rtx",
+                clockRate=90000,
+                payloadType=102,
+                parameters={"apt": 101},
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/VP9", clockRate=90000, payloadType=103
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/rtx",
+                clockRate=90000,
+                payloadType=104,
+                parameters={"apt": 103},
+            ),
+        ]
+
+        # Remote has collision: H264 RTX and VP9 main both at PT 103
+        remote_codecs = [
+            RTCRtpCodecParameters(
+                mimeType="video/H264",
+                clockRate=90000,
+                payloadType=102,
+                parameters={"profile-level-id": "42e01f"},
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/rtx",
+                clockRate=90000,
+                payloadType=103,  # RTX for H264 at 102
+                parameters={"apt": 102},
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/VP9", clockRate=90000, payloadType=103  # COLLISION!
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/rtx",
+                clockRate=90000,
+                payloadType=104,
+                parameters={"apt": 103},
+            ),
+        ]
+
+        common = find_common_codecs(local_codecs, remote_codecs)
+
+        # Should have 4 codecs with all unique PTs
+        self.assertEqual(len(common), 4)
+        pts = [c.payloadType for c in common]
+        self.assertEqual(len(pts), len(set(pts)), f"PT collision detected! PTs: {pts}")
+
+        # Verify each codec
+        h264 = next(c for c in common if c.mimeType == "video/H264")
+        self.assertEqual(h264.payloadType, 102)
+
+        h264_rtx = next(
+            c for c in common if c.mimeType == "video/rtx" and c.parameters["apt"] == 102
+        )
+        self.assertEqual(h264_rtx.payloadType, 103)
+
+        vp9 = next(c for c in common if c.mimeType == "video/VP9")
+        self.assertNotEqual(vp9.payloadType, 103, "VP9 should not use PT 103")
+        self.assertIn(vp9.payloadType, range(96, 128))
+
+        # VP9 RTX apt should reference VP9's assigned PT
+        vp9_rtx = next(
+            c
+            for c in common
+            if c.mimeType == "video/rtx" and c.parameters["apt"] == vp9.payloadType
+        )
+        self.assertIsNotNone(vp9_rtx)
+
+    def test_find_common_codecs_pt_collision_descending(self) -> None:
+        """
+        Test libwebrtc collision resolution uses descending search.
+        Multiple collisions should allocate from 127 downward.
+        """
+        local_codecs = [
+            RTCRtpCodecParameters(
+                mimeType="video/VP8", clockRate=90000, payloadType=97
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/VP9", clockRate=90000, payloadType=103
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/H264",
+                clockRate=90000,
+                payloadType=99,
+                parameters={"profile-level-id": "42e01f"},
+            ),
+        ]
+
+        # Remote uses same PT (100) for all codecs
+        remote_codecs = [
+            RTCRtpCodecParameters(
+                mimeType="video/VP8", clockRate=90000, payloadType=100
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/VP9", clockRate=90000, payloadType=100
+            ),
+            RTCRtpCodecParameters(
+                mimeType="video/H264",
+                clockRate=90000,
+                payloadType=100,
+                parameters={"profile-level-id": "42e01f"},
+            ),
+        ]
+
+        common = find_common_codecs(local_codecs, remote_codecs)
+
+        self.assertEqual(len(common), 3)
+        pts = [c.payloadType for c in common]
+        self.assertEqual(len(set(pts)), 3)
+
+        # First uses preferred PT 100
+        self.assertEqual(pts[0], 100)
+        # Subsequent use descending search: 127, 126
+        self.assertEqual(pts[1], 127)
+        self.assertEqual(pts[2], 126)
+
+    def test_find_common_codecs_bundle_collision(self) -> None:
+        """
+        Test BUNDLE PT collision prevention across media types.
+        When BUNDLE is active, PTs must be unique across audio and video.
+        """
+        # Shared PT namespace for BUNDLE (session-level)
+        used_payload_types: set[int] = set()
+
+        # Audio codecs
+        local_audio = [
+            RTCRtpCodecParameters(
+                mimeType="audio/opus", clockRate=48000, channels=2, payloadType=96
+            ),
+        ]
+        remote_audio = [
+            RTCRtpCodecParameters(
+                mimeType="audio/opus", clockRate=48000, channels=2, payloadType=97
+            ),
+        ]
+
+        # Video codecs - remote tries to use same PT 97!
+        local_video = [
+            RTCRtpCodecParameters(
+                mimeType="video/VP8", clockRate=90000, payloadType=100
+            ),
+        ]
+        remote_video = [
+            RTCRtpCodecParameters(
+                mimeType="video/VP8", clockRate=90000, payloadType=97  # COLLISION!
+            ),
+        ]
+
+        # Negotiate audio first (uses PT 97)
+        common_audio = find_common_codecs(
+            local_audio, remote_audio, used_payload_types
+        )
+        self.assertEqual(len(common_audio), 1)
+        self.assertEqual(common_audio[0].payloadType, 97)
+        self.assertIn(97, used_payload_types)
+
+        # Negotiate video second (PT 97 already used by audio!)
+        common_video = find_common_codecs(
+            local_video, remote_video, used_payload_types
+        )
+        self.assertEqual(len(common_video), 1)
+
+        # Video should NOT use PT 97 (collision with audio)
+        self.assertNotEqual(common_video[0].payloadType, 97)
+
+        # Video should use descending search: PT 127
+        self.assertEqual(common_video[0].payloadType, 127)
+
+        # Both PTs must be in the shared set and unique
+        self.assertIn(97, used_payload_types)  # audio
+        self.assertIn(127, used_payload_types)  # video
+        self.assertEqual(len(used_payload_types), 2)
+
 
 class RTCPeerConnectionTest(TestCase):
     def assertBundled(self, pc: RTCPeerConnection) -> None:

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -529,7 +529,7 @@ class RTCRtpCodecParametersTest(TestCase):
             ),
         ]
 
-        # Remote has collision: H264 RTX and VP9 main both at PT 103
+        # remote has collision: H264 RTX and VP9 both use PT 103
         remote_codecs = [
             RTCRtpCodecParameters(
                 mimeType="video/H264",
@@ -540,11 +540,11 @@ class RTCRtpCodecParametersTest(TestCase):
             RTCRtpCodecParameters(
                 mimeType="video/rtx",
                 clockRate=90000,
-                payloadType=103,  # RTX for H264 at 102
+                payloadType=103,
                 parameters={"apt": 102},
             ),
             RTCRtpCodecParameters(
-                mimeType="video/VP9", clockRate=90000, payloadType=103  # COLLISION!
+                mimeType="video/VP9", clockRate=90000, payloadType=103
             ),
             RTCRtpCodecParameters(
                 mimeType="video/rtx",
@@ -556,12 +556,12 @@ class RTCRtpCodecParametersTest(TestCase):
 
         common = find_common_codecs(local_codecs, remote_codecs)
 
-        # Should have 4 codecs with all unique PTs
+        # all PTs should be unique
         self.assertEqual(len(common), 4)
         pts = [c.payloadType for c in common]
-        self.assertEqual(len(pts), len(set(pts)), f"PT collision detected! PTs: {pts}")
+        self.assertEqual(len(pts), len(set(pts)))
 
-        # Verify each codec
+        # verify codec assignments
         h264 = next(c for c in common if c.mimeType == "video/H264")
         self.assertEqual(h264.payloadType, 102)
 
@@ -571,10 +571,9 @@ class RTCRtpCodecParametersTest(TestCase):
         self.assertEqual(h264_rtx.payloadType, 103)
 
         vp9 = next(c for c in common if c.mimeType == "video/VP9")
-        self.assertNotEqual(vp9.payloadType, 103, "VP9 should not use PT 103")
+        self.assertNotEqual(vp9.payloadType, 103)
         self.assertIn(vp9.payloadType, range(96, 128))
 
-        # VP9 RTX apt should reference VP9's assigned PT
         vp9_rtx = next(
             c
             for c in common
@@ -602,7 +601,7 @@ class RTCRtpCodecParametersTest(TestCase):
             ),
         ]
 
-        # Remote uses same PT (100) for all codecs
+        # remote uses same PT for all codecs
         remote_codecs = [
             RTCRtpCodecParameters(
                 mimeType="video/VP8", clockRate=90000, payloadType=100
@@ -624,21 +623,18 @@ class RTCRtpCodecParametersTest(TestCase):
         pts = [c.payloadType for c in common]
         self.assertEqual(len(set(pts)), 3)
 
-        # First uses preferred PT 100
+        # first codec uses preferred PT, subsequent use descending search
         self.assertEqual(pts[0], 100)
-        # Subsequent use descending search: 127, 126
         self.assertEqual(pts[1], 127)
         self.assertEqual(pts[2], 126)
 
     def test_find_common_codecs_bundle_collision(self) -> None:
         """
         Test BUNDLE PT collision prevention across media types.
-        When BUNDLE is active, PTs must be unique across audio and video.
         """
-        # Shared PT namespace for BUNDLE (session-level)
+        # shared PT namespace for BUNDLE
         used_payload_types: set[int] = set()
 
-        # Audio codecs
         local_audio = [
             RTCRtpCodecParameters(
                 mimeType="audio/opus", clockRate=48000, channels=2, payloadType=96
@@ -649,8 +645,6 @@ class RTCRtpCodecParametersTest(TestCase):
                 mimeType="audio/opus", clockRate=48000, channels=2, payloadType=97
             ),
         ]
-
-        # Video codecs - remote tries to use same PT 97!
         local_video = [
             RTCRtpCodecParameters(
                 mimeType="video/VP8", clockRate=90000, payloadType=100
@@ -658,11 +652,11 @@ class RTCRtpCodecParametersTest(TestCase):
         ]
         remote_video = [
             RTCRtpCodecParameters(
-                mimeType="video/VP8", clockRate=90000, payloadType=97  # COLLISION!
+                mimeType="video/VP8", clockRate=90000, payloadType=97
             ),
         ]
 
-        # Negotiate audio first (uses PT 97)
+        # negotiate audio first
         common_audio = find_common_codecs(
             local_audio, remote_audio, used_payload_types
         )
@@ -670,21 +664,16 @@ class RTCRtpCodecParametersTest(TestCase):
         self.assertEqual(common_audio[0].payloadType, 97)
         self.assertIn(97, used_payload_types)
 
-        # Negotiate video second (PT 97 already used by audio!)
+        # negotiate video second, PT 97 already used
         common_video = find_common_codecs(
             local_video, remote_video, used_payload_types
         )
         self.assertEqual(len(common_video), 1)
-
-        # Video should NOT use PT 97 (collision with audio)
         self.assertNotEqual(common_video[0].payloadType, 97)
-
-        # Video should use descending search: PT 127
         self.assertEqual(common_video[0].payloadType, 127)
 
-        # Both PTs must be in the shared set and unique
-        self.assertIn(97, used_payload_types)  # audio
-        self.assertIn(127, used_payload_types)  # video
+        self.assertIn(97, used_payload_types)
+        self.assertIn(127, used_payload_types)
         self.assertEqual(len(used_payload_types), 2)
 
 

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -501,10 +501,9 @@ class RTCRtpCodecParametersTest(TestCase):
             )
         )
 
-    def test_find_common_codecs_pt_collision_pr1390(self) -> None:
+    def test_find_common_codecs_pt_collision_rtx_and_codec(self) -> None:
         """
-        Test PT collision fix for PR #1390.
-        Remote has H264 RTX at PT 103, then VP9 main also at PT 103.
+        Test PT collision when remote has RTX and main codec at same PT.
         """
         local_codecs = [
             RTCRtpCodecParameters(

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -5150,69 +5150,6 @@ a=rtpmap:0 PCMU/8000
         await pc.close()
 
     @asynctest
-    async def test_setRemoteDescription_pt_collision_in_offer(self) -> None:
-        """
-        Test PT collision fix: H264 RTX and VP8 both at PT 103 in remote offer.
-        """
-        # SDP with collision: H264 at PT 102, H264 RTX at PT 103, VP8 at PT 103
-        problematic_sdp = lf2crlf(
-            """v=0
-o=- 1234567890 2 IN IP4 127.0.0.1
-s=-
-t=0 0
-a=group:BUNDLE 0
-a=msid-semantic: WMS stream
-m=video 9 UDP/TLS/RTP/SAVPF 102 103 103 104
-c=IN IP4 0.0.0.0
-a=rtcp:9 IN IP4 0.0.0.0
-a=ice-ufrag:testufrag
-a=ice-pwd:testpwdtestpwdtestpwdtest
-a=ice-options:trickle
-a=fingerprint:sha-256 00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00:00
-a=setup:actpass
-a=mid:0
-a=sendrecv
-a=rtcp-mux
-a=rtpmap:102 H264/90000
-a=rtcp-fb:102 nack
-a=rtcp-fb:102 nack pli
-a=rtcp-fb:102 goog-remb
-a=fmtp:102 level-asymmetry-allowed=1;packetization-mode=1;profile-level-id=42e01f
-a=rtpmap:103 rtx/90000
-a=fmtp:103 apt=102
-a=rtpmap:103 VP8/90000
-a=rtcp-fb:103 nack
-a=rtcp-fb:103 nack pli
-a=rtcp-fb:103 goog-remb
-a=rtpmap:104 rtx/90000
-a=fmtp:104 apt=103
-a=ssrc:1111111111 cname:testcname
-"""
-        )
-
-        pc = RTCPeerConnection()
-
-        # Set the problematic offer as remote description
-        await pc.setRemoteDescription(
-            RTCSessionDescription(sdp=problematic_sdp, type="offer")
-        )
-
-        # Create answer
-        answer = await pc.createAnswer()
-        await pc.setLocalDescription(answer)
-
-        # Extract payload types from answer SDP
-        pts_in_answer = re.findall(r"a=rtpmap:(\d+)\s+", answer.sdp)
-        pts_in_answer = [int(pt) for pt in pts_in_answer]
-
-        # Verify all PTs are unique (no collisions)
-        self.assertEqual(len(pts_in_answer), len(set(pts_in_answer)))
-        self.assertGreaterEqual(len(pts_in_answer), 2)
-
-        # close
-        await pc.close()
-
-    @asynctest
     async def test_setRemoteDescription_media_datachannel_bundled(self) -> None:
         pc1 = RTCPeerConnection()
         pc2 = RTCPeerConnection()


### PR DESCRIPTION
## Summary

Fixes payload type (PT) collision issues during SDP offer/answer negotiation, implementing libwebrtc's collision resolution algorithm.

### Problem

When negotiating codecs, aiortc could assign the same payload type to multiple codecs. This happens when:
1. Remote SDP has duplicate PTs (e.g., RTX codec and main codec both using PT 103)
2. BUNDLE groups share a PT namespace across audio/video m-lines

Browsers reject SDP with duplicate payload types, causing connection failures.

### Solution

- **PT collision resolution**: When a preferred PT is already in use, search for an unused PT in the dynamic range [96-127], descending from 127 (matching libwebrtc behavior)
- **BUNDLE namespace tracking**: Pass a shared `used_payload_types` set across media negotiation when BUNDLE is active (RFC 8834)
- **RTX apt updates**: When a base codec's PT is reassigned, update the corresponding RTX codec's `apt` parameter to match

### Changes

**`rtcpeerconnection.py`**:
- Add `used_payload_types` parameter to `find_common_codecs()` for session-wide PT tracking
- Implement `find_unused_id()` - searches [127→96] for available PT
- Implement `find_and_set_id_used()` - assigns PT with collision handling
- Track BUNDLE groups and share PT namespace across media lines
- Update RTX `apt` parameter when base codec PT changes

**`test_rtcpeerconnection.py`**:
- `test_find_common_codecs_pt_collision_rtx_and_codec`: RTX/codec collision scenario
- `test_find_common_codecs_pt_collision_descending`: Multiple collisions use descending search
- `test_find_common_codecs_bundle_collision`: Cross-media PT collision in BUNDLE

### Related

This fix was originally part of #1390 (VP9 support) and has been split into a separate PR per maintainer request.
