### PR TITLE
feat: Add iceTransportPolicy support to RTCConfiguration

### DIFF
--- a/src/aiortc/__init__.py
+++ b/src/aiortc/__init__.py
@@ -8,7 +8,12 @@ from .mediastreams import (
     MediaStreamTrack,
     VideoStreamTrack,
 )
-from .rtcconfiguration import RTCBundlePolicy, RTCConfiguration, RTCIceServer
+from .rtcconfiguration import (
+    RTCBundlePolicy,
+    RTCConfiguration,
+    RTCIceServer,
+    RTCIceTransportPolicy,
+)
 from .rtcdatachannel import RTCDataChannel, RTCDataChannelParameters
 from .rtcdtlstransport import (
     RTCCertificate,
@@ -74,6 +79,7 @@ __all__ = [
     "RTCIceParameters",
     "RTCIceServer",
     "RTCIceTransport",
+    "RTCIceTransportPolicy",
     "RTCInboundRtpStreamStats",
     "RTCOutboundRtpStreamStats",
     "RTCPeerConnection",

--- a/src/aiortc/rtcconfiguration.py
+++ b/src/aiortc/rtcconfiguration.py
@@ -52,6 +52,26 @@ class RTCBundlePolicy(enum.Enum):
     """
 
 
+class RTCIceTransportPolicy(enum.Enum):
+    """
+    The :class:`RTCIceTransportPolicy` restricts the type of ICE candidates
+    that can be used.
+
+    See https://w3c.github.io/webrtc-pc/#rtcice-transport-policy-enum
+    """
+
+    ALL = "all"
+    """
+    All ICE candidates are considered.
+    """
+
+    RELAY = "relay"
+    """
+    Only ICE candidates whose IP addresses are being relayed, such as those
+    from a TURN server, are considered.
+    """
+
+
 @dataclass
 class RTCConfiguration:
     """
@@ -64,6 +84,9 @@ class RTCConfiguration:
 
     bundlePolicy: RTCBundlePolicy = RTCBundlePolicy.BALANCED
     "The media-bundling policy to use when gathering ICE candidates."
+
+    iceTransportPolicy: Optional[RTCIceTransportPolicy] = None
+    "The ICE transport policy to use."
 
     alwaysNegotiateDataChannels: bool = False
     "Whether to always negotiate data channels in the SDP."

--- a/src/aiortc/rtcicetransport.py
+++ b/src/aiortc/rtcicetransport.py
@@ -93,8 +93,14 @@ def candidate_to_aioice(x: RTCIceCandidate) -> Candidate:
     )
 
 
-def connection_kwargs(servers: list[RTCIceServer]) -> dict[str, Any]:
+def connection_kwargs(
+    servers: list[RTCIceServer], transport_policy: Optional[str] = None
+) -> dict[str, Any]:
     kwargs: dict[str, Any] = {}
+
+    if transport_policy:
+        kwargs["transport_policy"] = transport_policy
+
 
     for server in servers:
         if isinstance(server.urls, list):
@@ -184,6 +190,7 @@ class RTCIceGatherer(AsyncIOEventEmitter):
     def __init__(
         self,
         iceServers: Optional[list[RTCIceServer]] = None,
+        iceTransportPolicy: Optional[RTCIceTransportPolicy] = None,
         local_username: Optional[str] = None,
         local_password: Optional[str] = None,
     ) -> None:
@@ -191,7 +198,10 @@ class RTCIceGatherer(AsyncIOEventEmitter):
 
         if iceServers is None:
             iceServers = self.getDefaultIceServers()
-        ice_kwargs = connection_kwargs(iceServers)
+        ice_kwargs = connection_kwargs(
+            iceServers,
+            transport_policy=iceTransportPolicy.value if iceTransportPolicy else None,
+        )
 
         self._connection = Connection(
             ice_controlling=False,

--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -1128,11 +1128,15 @@ class RTCPeerConnection(AsyncIOEventEmitter):
                 )
             iceGatherer = RTCIceGatherer(
                 iceServers=self.__configuration.iceServers,
+                iceTransportPolicy=self.__configuration.iceTransportPolicy,
                 local_username=parameters.usernameFragment,
                 local_password=parameters.password,
             )
         else:
-            iceGatherer = RTCIceGatherer(iceServers=self.__configuration.iceServers)
+            iceGatherer = RTCIceGatherer(
+                iceServers=self.__configuration.iceServers,
+                iceTransportPolicy=self.__configuration.iceTransportPolicy,
+            )
 
         iceGatherer.on("statechange", self.__updateIceGatheringState)
         iceTransport = RTCIceTransport(iceGatherer)

--- a/tests/test_rtcicetransport.py
+++ b/tests/test_rtcicetransport.py
@@ -1,11 +1,12 @@
 import asyncio
-from typing import Optional
+from typing import Any, Optional
+from unittest.mock import AsyncMock, patch
 
 import aioice.ice
 import aioice.stun
 from aioice import ConnectionClosed
 from aiortc.exceptions import InvalidStateError
-from aiortc.rtcconfiguration import RTCIceServer
+from aiortc.rtcconfiguration import RTCIceServer, RTCIceTransportPolicy
 from aiortc.rtcicetransport import (
     RTCIceCandidate,
     RTCIceGatherer,
@@ -183,6 +184,16 @@ class ConnectionKwargsTest(TestCase):
         )
 
 
+    def test_transport_policy(self) -> None:
+        self.assertEqual(
+            connection_kwargs([], transport_policy="all"), {"transport_policy": "all"}
+        )
+        self.assertEqual(
+            connection_kwargs([], transport_policy="relay"),
+            {"transport_policy": "relay"},
+        )
+
+
 class ParseStunTurnUriTest(TestCase):
     def test_invalid_scheme(self) -> None:
         with self.assertRaises(ValueError) as cm:
@@ -257,6 +268,25 @@ class RTCIceGathererTest(TestCase):
             RTCIceGatherer.getDefaultIceServers(),
             [RTCIceServer(urls="stun:stun.l.google.com:19302")],
         )
+
+    @asynctest
+    @patch("aiortc.rtcicetransport.Connection")
+    async def test_gather_relay(self, mock_connection: Any) -> None:
+        mock_connection.return_value.gather_candidates = AsyncMock()
+        mock_connection.return_value.close = AsyncMock()
+
+        gatherer = RTCIceGatherer(iceTransportPolicy=RTCIceTransportPolicy.RELAY)
+        mock_connection.assert_called_once_with(
+            ice_controlling=False,
+            local_username=None,
+            local_password=None,
+            stun_server=("stun.l.google.com", 19302),
+            transport_policy="relay",
+        )
+        self.assertEqual(gatherer.state, "new")
+        await gatherer.gather()
+        self.assertEqual(gatherer.state, "completed")
+        await gatherer._connection.close()
 
 
 class RTCIceTransportTest(TestCase):


### PR DESCRIPTION
Implements `iceTransportPolicy` for `RTCConfiguration` to control ICE candidate gathering, including a new `RTCIceTransportPolicy` enum and integration with `aioice.Connection`.

Closes #1397