### PR TITLE
Add TWCC (Transport-Wide Congestion Control) support

### DIFF
--- a/examples/webcam/webcam.py
+++ b/examples/webcam/webcam.py
@@ -18,6 +18,52 @@ from aiortc.contrib.media import MediaPlayer, MediaRelay
 
 ROOT = os.path.dirname(__file__)
 
+logger = logging.getLogger(__name__)
+
+
+class SimpleCongestionController:
+    """AIMD congestion controller driven by TWCC feedback."""
+
+    def __init__(self, pc, sender):
+        self.sender = sender
+        self.bitrate = 1_000_000  # initial 1 Mbps
+
+        @pc.on("twcc")
+        def on_twcc(feedback):
+            total = len(feedback.results)
+            if total == 0:
+                return
+            lost = sum(1 for r in feedback.results if r.lost)
+            loss_rate = lost / total
+
+            # compute one-way delay gradient
+            prev_send = None
+            prev_recv = None
+            delay_gradients = []
+            for r in feedback.results:
+                if r.lost or r.send_time is None:
+                    prev_send = None
+                    continue
+                if prev_send is not None:
+                    send_delta = r.send_time - prev_send
+                    recv_delta = (r.recv_delta_us - prev_recv) / 1e6
+                    delay_gradients.append(recv_delta - send_delta)
+                prev_send = r.send_time
+                prev_recv = r.recv_delta_us
+
+            # simple AIMD
+            if loss_rate > 0.1 or (
+                delay_gradients
+                and sum(delay_gradients) / len(delay_gradients) > 0.005
+            ):
+                self.bitrate = int(self.bitrate * 0.85)
+            else:
+                self.bitrate = int(self.bitrate * 1.05)
+
+            self.bitrate = max(100_000, min(self.bitrate, 10_000_000))
+            self.sender.set_target_bitrate(self.bitrate)
+            logger.debug("TWCC: target bitrate %d bps", self.bitrate)
+
 pcs = set()
 relay = None
 webcam = None
@@ -105,6 +151,7 @@ async def offer(request: web.Request) -> web.Response:
             force_codec(pc, video_sender, args.video_codec)
         elif args.play_without_decoding:
             raise Exception("You must specify the video codec using --video-codec")
+        SimpleCongestionController(pc, video_sender)
 
     await pc.setRemoteDescription(offer)
 

--- a/examples/webcam/webcam.py
+++ b/examples/webcam/webcam.py
@@ -52,8 +52,7 @@ class SimpleCongestionController:
                 prev_recv = r.recv_delta_us
 
             avg_delay = (
-                sum(delay_gradients) / len(delay_gradients)
-                if delay_gradients else 0.0
+                sum(delay_gradients) / len(delay_gradients) if delay_gradients else 0.0
             )
 
             old_bitrate = self.bitrate
@@ -71,10 +70,11 @@ class SimpleCongestionController:
 
             print(
                 f"[TWCC] pkts={total} lost={lost} loss={loss_rate:.1%} "
-                f"avg_delay={avg_delay*1000:.2f}ms "
-                f"bitrate {old_bitrate//1000}k -> {self.bitrate//1000}k kbps "
+                f"avg_delay={avg_delay * 1000:.2f}ms "
+                f"bitrate {old_bitrate // 1000}k -> {self.bitrate // 1000}k kbps "
                 f"({action})"
             )
+
 
 pcs = set()
 relay = None

--- a/examples/webcam/webcam.py
+++ b/examples/webcam/webcam.py
@@ -51,18 +51,30 @@ class SimpleCongestionController:
                 prev_send = r.send_time
                 prev_recv = r.recv_delta_us
 
+            avg_delay = (
+                sum(delay_gradients) / len(delay_gradients)
+                if delay_gradients else 0.0
+            )
+
+            old_bitrate = self.bitrate
+
             # simple AIMD
-            if loss_rate > 0.1 or (
-                delay_gradients
-                and sum(delay_gradients) / len(delay_gradients) > 0.005
-            ):
+            if loss_rate > 0.1 or avg_delay > 0.005:
                 self.bitrate = int(self.bitrate * 0.85)
+                action = "DECREASE"
             else:
                 self.bitrate = int(self.bitrate * 1.05)
+                action = "increase"
 
             self.bitrate = max(100_000, min(self.bitrate, 10_000_000))
             self.sender.set_target_bitrate(self.bitrate)
-            logger.debug("TWCC: target bitrate %d bps", self.bitrate)
+
+            print(
+                f"[TWCC] pkts={total} lost={lost} loss={loss_rate:.1%} "
+                f"avg_delay={avg_delay*1000:.2f}ms "
+                f"bitrate {old_bitrate//1000}k -> {self.bitrate//1000}k kbps "
+                f"({action})"
+            )
 
 pcs = set()
 relay = None

--- a/src/aiortc/codecs/__init__.py
+++ b/src/aiortc/codecs/__init__.py
@@ -50,6 +50,10 @@ HEADER_EXTENSIONS: dict[str, list[RTCRtpHeaderExtensionParameters]] = {
         RTCRtpHeaderExtensionParameters(
             id=2, uri="urn:ietf:params:rtp-hdrext:ssrc-audio-level"
         ),
+        RTCRtpHeaderExtensionParameters(
+            id=5,
+            uri="http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
+        ),
     ],
     "video": [
         RTCRtpHeaderExtensionParameters(
@@ -57,6 +61,10 @@ HEADER_EXTENSIONS: dict[str, list[RTCRtpHeaderExtensionParameters]] = {
         ),
         RTCRtpHeaderExtensionParameters(
             id=3, uri="http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+        ),
+        RTCRtpHeaderExtensionParameters(
+            id=5,
+            uri="http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01",
         ),
     ],
 }

--- a/src/aiortc/rtcdtlstransport.py
+++ b/src/aiortc/rtcdtlstransport.py
@@ -28,6 +28,7 @@ from .rtp import (
     RtcpRrPacket,
     RtcpRtpfbPacket,
     RtcpSrPacket,
+    RtcpTwccPacket,
     RtpPacket,
     is_rtcp,
 )
@@ -292,6 +293,10 @@ class RtpRouter:
         if isinstance(packet, (RtcpRrPacket, RtcpSrPacket)):
             for report in packet.reports:
                 add_recipient(self.senders.get(report.ssrc))
+        elif isinstance(packet, RtcpTwccPacket):
+            # TWCC feedback is transport-wide, route to all senders
+            for sender in self.senders.values():
+                recipients.add(sender)
         elif isinstance(packet, (RtcpPsfbPacket, RtcpRtpfbPacket)):
             add_recipient(self.senders.get(packet.media_ssrc))
 
@@ -370,6 +375,9 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
         self.__rx_packets = 0
         self.__tx_bytes = 0
         self.__tx_packets = 0
+
+        # TWCC
+        self._twcc_sequence_number: int = 0
 
         # SRTP
         self._rx_srtp: Session = None
@@ -577,6 +585,11 @@ class RTCDtlsTransport(AsyncIOEventEmitter):
             raise exc
         finally:
             self._set_state(State.CLOSED)
+
+    def _next_twcc_sequence_number(self) -> int:
+        seq = self._twcc_sequence_number
+        self._twcc_sequence_number = (seq + 1) & 0xFFFF
+        return seq
 
     def _get_stats(self) -> RTCStatsReport:
         report = RTCStatsReport()

--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -1200,6 +1200,9 @@ class RTCPeerConnection(AsyncIOEventEmitter):
             receiver=RTCRtpReceiver(kind, dtlsTransport),
         )
         transceiver.receiver._set_rtcp_ssrc(transceiver.sender._ssrc)
+        transceiver.sender._set_twcc_callback(
+            lambda feedback: self.emit("twcc", feedback)
+        )
         transceiver.sender._stream_id = self.__stream_id
         transceiver._bundled = bundled
         self.__transceivers.append(transceiver)

--- a/src/aiortc/rtcpeerconnection.py
+++ b/src/aiortc/rtcpeerconnection.py
@@ -36,7 +36,7 @@ from .rtcrtpparameters import (
     RTCRtpSendParameters,
 )
 from .rtcrtpreceiver import RemoteStreamTrack, RTCRtpReceiver
-from .rtcrtpsender import RTCRtpSender
+from .rtcrtpsender import RTCRtpSender, TwccFeedback
 from .rtcrtptransceiver import RTCRtpTransceiver
 from .rtcsctptransport import RTCSctpCapabilities, RTCSctpTransport
 from .rtcsessiondescription import RTCSessionDescription
@@ -1200,9 +1200,11 @@ class RTCPeerConnection(AsyncIOEventEmitter):
             receiver=RTCRtpReceiver(kind, dtlsTransport),
         )
         transceiver.receiver._set_rtcp_ssrc(transceiver.sender._ssrc)
-        transceiver.sender._set_twcc_callback(
-            lambda feedback: self.emit("twcc", feedback)
-        )
+
+        def _twcc_cb(feedback: "TwccFeedback") -> None:
+            self.emit("twcc", feedback)
+
+        transceiver.sender._set_twcc_callback(_twcc_cb)
         transceiver.sender._stream_id = self.__stream_id
         transceiver._bundled = bundled
         self.__transceivers.append(transceiver)

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -35,6 +35,7 @@ from .rtp import (
     RtcpRrPacket,
     RtcpRtpfbPacket,
     RtcpSrPacket,
+    RtcpTwccPacket,
     RtpPacket,
     clamp_packets_lost,
     pack_remb_fci,
@@ -45,7 +46,7 @@ from .stats import (
     RTCRemoteOutboundRtpStreamStats,
     RTCStatsReport,
 )
-from .utils import uint16_add, uint16_gt
+from .utils import uint16_add, uint16_gt, uint16_gte
 
 logger = logging.getLogger(__name__)
 
@@ -188,6 +189,88 @@ class StreamStatistics:
         return clamp_packets_lost(self.packets_expected - self.packets_received)
 
 
+class TwccTracker:
+    DELTA_UNIT_US = 250
+    REF_TIME_UNIT_US = 64_000
+
+    def __init__(self) -> None:
+        self._packets: dict[int, int] = {}  # twcc_seq -> arrival_time_us
+        self._min_seq: Optional[int] = None
+        self._max_seq: Optional[int] = None
+        self._feedback_count: int = 0
+
+    def add(self, twcc_seq: int, arrival_time_us: int) -> None:
+        if twcc_seq in self._packets:
+            return  # skip duplicates
+        self._packets[twcc_seq] = arrival_time_us
+        if self._min_seq is None or uint16_gt(self._min_seq, twcc_seq):
+            self._min_seq = twcc_seq
+        if self._max_seq is None or uint16_gt(twcc_seq, self._max_seq):
+            self._max_seq = twcc_seq
+
+    def build_feedback(
+        self, ssrc: int, media_ssrc: int
+    ) -> Optional[RtcpTwccPacket]:
+        if self._min_seq is None or self._max_seq is None or not self._packets:
+            return None
+
+        base_seq = self._min_seq
+
+        # Iterate from min_seq to max_seq (uint16 wraparound aware)
+        seq = base_seq
+        packet_results: list[tuple[int, Optional[int]]] = []
+
+        # Find reference time from first received packet
+        ref_time_us: Optional[int] = None
+        s = base_seq
+        while True:
+            if s in self._packets:
+                ref_time_us = self._packets[s]
+                break
+            if s == self._max_seq:
+                break
+            s = (s + 1) & 0xFFFF
+        if ref_time_us is None:
+            return None
+
+        reference_time = ref_time_us // self.REF_TIME_UNIT_US
+        # Adjust for signed 24-bit
+        if ref_time_us < 0:
+            reference_time = -((-ref_time_us + self.REF_TIME_UNIT_US - 1) // self.REF_TIME_UNIT_US)
+
+        ref_base_us = reference_time * self.REF_TIME_UNIT_US
+
+        seq = base_seq
+        while True:
+            arrival = self._packets.get(seq)
+            if arrival is None:
+                packet_results.append((seq, None))
+            else:
+                recv_delta_us = arrival - ref_base_us
+                packet_results.append((seq, recv_delta_us))
+            if seq == self._max_seq:
+                break
+            seq = (seq + 1) & 0xFFFF
+
+        fb_count = self._feedback_count & 0xFF
+        self._feedback_count = (self._feedback_count + 1) & 0xFF
+
+        # Clear state
+        self._packets.clear()
+        self._min_seq = None
+        self._max_seq = None
+
+        return RtcpTwccPacket(
+            ssrc=ssrc,
+            media_ssrc=media_ssrc,
+            base_sequence_number=base_seq,
+            packet_status_count=len(packet_results),
+            reference_time=reference_time,
+            feedback_packet_count=fb_count,
+            packet_results=packet_results,
+        )
+
+
 class RemoteStreamTrack(MediaStreamTrack):
     def __init__(self, kind: str, id: Optional[str] = None) -> None:
         super().__init__()
@@ -285,6 +368,7 @@ class RTCRtpReceiver:
         self.__rtcp_started = asyncio.Event()
         self.__rtcp_task: Optional[asyncio.Future[None]] = None
         self.__rtx_ssrc: dict[int, int] = {}
+        self.__twcc_tracker: Optional[TwccTracker] = None
         self.__started = False
         self.__stats = RTCStatsReport()
         self.__timestamp_mapper = TimestampMapper()
@@ -383,6 +467,13 @@ class RTCRtpReceiver:
                 if encoding.rtx:
                     self.__rtx_ssrc[encoding.rtx.ssrc] = encoding.ssrc
 
+            # check if TWCC extension is negotiated
+            twcc_uri = "http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
+            for ext in parameters.headerExtensions:
+                if ext.uri == twcc_uri:
+                    self.__twcc_tracker = TwccTracker()
+                    break
+
             # start decoder thread
             self.__decoder_thread = threading.Thread(
                 target=decoder_worker,
@@ -457,6 +548,16 @@ class RTCRtpReceiver:
         # If the receiver is disabled, discard the packet.
         if not self._enabled:
             return
+
+        # feed TWCC tracker
+        if (
+            self.__twcc_tracker is not None
+            and packet.extensions.transport_sequence_number is not None
+        ):
+            self.__twcc_tracker.add(
+                packet.extensions.transport_sequence_number,
+                arrival_time_ms * 1000,
+            )
 
         # feed bitrate estimator
         if self.__remote_bitrate_estimator is not None:
@@ -545,10 +646,33 @@ class RTCRtpReceiver:
         self.__rtcp_started.set()
 
         try:
+            rr_counter = 0
             while True:
-                # The interval between RTCP packets is varied randomly over the
-                # range [0.5, 1.5] times the calculated interval.
-                await asyncio.sleep(0.5 + random.random())
+                if self.__twcc_tracker is not None:
+                    # Shorter interval for TWCC feedback (~100ms with jitter)
+                    await asyncio.sleep(0.05 + random.random() * 0.1)
+                else:
+                    # The interval between RTCP packets is varied randomly over
+                    # the range [0.5, 1.5] times the calculated interval.
+                    await asyncio.sleep(0.5 + random.random())
+
+                # TWCC feedback
+                if (
+                    self.__twcc_tracker is not None
+                    and self.__rtcp_ssrc is not None
+                ):
+                    twcc_packet = self.__twcc_tracker.build_feedback(
+                        ssrc=self.__rtcp_ssrc, media_ssrc=0
+                    )
+                    if twcc_packet is not None:
+                        await self._send_rtcp(twcc_packet)
+
+                rr_counter += 1
+
+                # Send RR at reduced frequency when TWCC is active
+                if self.__twcc_tracker is not None and rr_counter < 10:
+                    continue
+                rr_counter = 0
 
                 # RTCP RR
                 reports = []

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -46,7 +46,7 @@ from .stats import (
     RTCRemoteOutboundRtpStreamStats,
     RTCStatsReport,
 )
-from .utils import uint16_add, uint16_gt, uint16_gte
+from .utils import uint16_add, uint16_gt
 
 logger = logging.getLogger(__name__)
 
@@ -234,9 +234,6 @@ class TwccTracker:
             return None
 
         reference_time = ref_time_us // self.REF_TIME_UNIT_US
-        # Adjust for signed 24-bit
-        if ref_time_us < 0:
-            reference_time = -((-ref_time_us + self.REF_TIME_UNIT_US - 1) // self.REF_TIME_UNIT_US)
 
         ref_base_us = reference_time * self.REF_TIME_UNIT_US
 

--- a/src/aiortc/rtcrtpreceiver.py
+++ b/src/aiortc/rtcrtpreceiver.py
@@ -208,9 +208,7 @@ class TwccTracker:
         if self._max_seq is None or uint16_gt(twcc_seq, self._max_seq):
             self._max_seq = twcc_seq
 
-    def build_feedback(
-        self, ssrc: int, media_ssrc: int
-    ) -> Optional[RtcpTwccPacket]:
+    def build_feedback(self, ssrc: int, media_ssrc: int) -> Optional[RtcpTwccPacket]:
         if self._min_seq is None or self._max_seq is None or not self._packets:
             return None
 
@@ -654,10 +652,7 @@ class RTCRtpReceiver:
                     await asyncio.sleep(0.5 + random.random())
 
                 # TWCC feedback
-                if (
-                    self.__twcc_tracker is not None
-                    and self.__rtcp_ssrc is not None
-                ):
+                if self.__twcc_tracker is not None and self.__rtcp_ssrc is not None:
                     twcc_packet = self.__twcc_tracker.build_feedback(
                         ssrc=self.__rtcp_ssrc, media_ssrc=0
                     )

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -70,16 +70,16 @@ def random_sequence_number() -> int:
 
 @dataclass
 class TwccPacketResult:
-    seq: int                        # transport-wide sequence number
-    send_time: Optional[float]      # time.time() when sent, None if not in log
-    recv_delta_us: Optional[int]    # microseconds from ref_time, None = lost
-    lost: bool                      # True if recv_delta_us is None
+    seq: int  # transport-wide sequence number
+    send_time: Optional[float]  # time.time() when sent, None if not in log
+    recv_delta_us: Optional[int]  # microseconds from ref_time, None = lost
+    lost: bool  # True if recv_delta_us is None
 
 
 @dataclass
 class TwccFeedback:
-    packet: RtcpTwccPacket          # raw RTCP packet
-    results: list[TwccPacketResult] # pre-joined per-packet records
+    packet: RtcpTwccPacket  # raw RTCP packet
+    results: list[TwccPacketResult]  # pre-joined per-packet records
 
 
 class RTCEncodedFrame:
@@ -311,12 +311,14 @@ class RTCRtpSender:
             results = []
             for seq_num, recv_delta_us in packet.packet_results:
                 send_time = self.__twcc_send_log.pop(seq_num, None)
-                results.append(TwccPacketResult(
-                    seq=seq_num,
-                    send_time=send_time,
-                    recv_delta_us=recv_delta_us,
-                    lost=recv_delta_us is None,
-                ))
+                results.append(
+                    TwccPacketResult(
+                        seq=seq_num,
+                        send_time=send_time,
+                        recv_delta_us=recv_delta_us,
+                        lost=recv_delta_us is None,
+                    )
+                )
             if self.__twcc_callback is not None:
                 self.__twcc_callback(TwccFeedback(packet=packet, results=results))
         elif isinstance(packet, RtcpPsfbPacket) and packet.fmt == RTCP_PSFB_APP:

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -6,6 +6,7 @@ import traceback
 import uuid
 from collections import OrderedDict
 from collections.abc import Callable
+from dataclasses import dataclass
 from typing import Optional, Union
 
 from av import AudioFrame
@@ -67,6 +68,20 @@ def random_sequence_number() -> int:
     return random16() % 32768
 
 
+@dataclass
+class TwccPacketResult:
+    seq: int                        # transport-wide sequence number
+    send_time: Optional[float]      # time.time() when sent, None if not in log
+    recv_delta_us: Optional[int]    # microseconds from ref_time, None = lost
+    lost: bool                      # True if recv_delta_us is None
+
+
+@dataclass
+class TwccFeedback:
+    packet: RtcpTwccPacket          # raw RTCP packet
+    results: list[TwccPacketResult] # pre-joined per-packet records
+
+
 class RTCEncodedFrame:
     def __init__(self, payloads: list[bytes], timestamp: int, audio_level: int):
         self.payloads = payloads
@@ -118,6 +133,7 @@ class RTCRtpSender:
         self.__rtx_payload_type: Optional[int] = None
         self.__rtx_sequence_number = random_sequence_number()
         self.__twcc_send_log: OrderedDict[int, float] = OrderedDict()
+        self.__twcc_callback: Optional[Callable[[TwccFeedback], None]] = None
         self.__started = False
         self.__stats = RTCStatsReport()
         self.__transport = transport
@@ -204,6 +220,15 @@ class RTCRtpSender:
     def setTransport(self, transport: RTCDtlsTransport) -> None:
         self.__transport = transport
 
+    def _set_twcc_callback(
+        self, callback: Optional[Callable[[TwccFeedback], None]]
+    ) -> None:
+        self.__twcc_callback = callback
+
+    def set_target_bitrate(self, bitrate: int) -> None:
+        if self.__encoder and hasattr(self.__encoder, "target_bitrate"):
+            self.__encoder.target_bitrate = bitrate
+
     async def send(self, parameters: RTCRtpSendParameters) -> None:
         """
         Attempt to set the parameters controlling the sending of media.
@@ -283,8 +308,17 @@ class RTCRtpSender:
         ):
             self._send_keyframe()
         elif isinstance(packet, RtcpTwccPacket):
+            results = []
             for seq_num, recv_delta_us in packet.packet_results:
-                self.__twcc_send_log.pop(seq_num, None)
+                send_time = self.__twcc_send_log.pop(seq_num, None)
+                results.append(TwccPacketResult(
+                    seq=seq_num,
+                    send_time=send_time,
+                    recv_delta_us=recv_delta_us,
+                    lost=recv_delta_us is None,
+                ))
+            if self.__twcc_callback is not None:
+                self.__twcc_callback(TwccFeedback(packet=packet, results=results))
         elif isinstance(packet, RtcpPsfbPacket) and packet.fmt == RTCP_PSFB_APP:
             try:
                 bitrate, ssrcs = unpack_remb_fci(packet.fci)

--- a/src/aiortc/rtcrtpsender.py
+++ b/src/aiortc/rtcrtpsender.py
@@ -4,6 +4,7 @@ import random
 import time
 import traceback
 import uuid
+from collections import OrderedDict
 from collections.abc import Callable
 from typing import Optional, Union
 
@@ -36,6 +37,7 @@ from .rtp import (
     RtcpSenderInfo,
     RtcpSourceInfo,
     RtcpSrPacket,
+    RtcpTwccPacket,
     RtpPacket,
     unpack_remb_fci,
     wrap_rtx,
@@ -115,6 +117,7 @@ class RTCRtpSender:
         self.__rtcp_task: Optional[asyncio.Future[None]] = None
         self.__rtx_payload_type: Optional[int] = None
         self.__rtx_sequence_number = random_sequence_number()
+        self.__twcc_send_log: OrderedDict[int, float] = OrderedDict()
         self.__started = False
         self.__stats = RTCStatsReport()
         self.__transport = transport
@@ -279,6 +282,9 @@ class RTCRtpSender:
             RTCP_PSFB_PLI,  # Picture Loss Indication
         ):
             self._send_keyframe()
+        elif isinstance(packet, RtcpTwccPacket):
+            for seq_num, recv_delta_us in packet.packet_results:
+                self.__twcc_send_log.pop(seq_num, None)
         elif isinstance(packet, RtcpPsfbPacket) and packet.fmt == RTCP_PSFB_APP:
             try:
                 bitrate, ssrcs = unpack_remb_fci(packet.fci)
@@ -391,6 +397,16 @@ class RTCRtpSender:
                     packet.extensions.mid = self.__mid
                     if enc_frame.audio_level is not None:
                         packet.extensions.audio_level = (False, -enc_frame.audio_level)
+
+                    # stamp transport-wide sequence number
+                    packet.extensions.transport_sequence_number = (
+                        self.__transport._next_twcc_sequence_number()
+                    )
+                    self.__twcc_send_log[
+                        packet.extensions.transport_sequence_number
+                    ] = time.time()
+                    while len(self.__twcc_send_log) > 4000:
+                        self.__twcc_send_log.popitem(last=False)
 
                     # send packet
                     self.__log_debug("> %s", packet)

--- a/src/aiortc/rtp.py
+++ b/src/aiortc/rtp.py
@@ -689,9 +689,7 @@ class RtcpTwccPacket:
         ref_time = self.reference_time & 0xFFFFFF
 
         payload = pack("!LL", self.ssrc, self.media_ssrc)
-        payload += pack(
-            "!HH", self.base_sequence_number, self.packet_status_count
-        )
+        payload += pack("!HH", self.base_sequence_number, self.packet_status_count)
         payload += pack("!B", (ref_time >> 16) & 0xFF)
         payload += pack("!B", (ref_time >> 8) & 0xFF)
         payload += pack("!B", ref_time & 0xFF)

--- a/src/aiortc/rtp.py
+++ b/src/aiortc/rtp.py
@@ -30,6 +30,7 @@ RTCP_RTPFB = 205
 RTCP_PSFB = 206
 
 RTCP_RTPFB_NACK = 1
+RTCP_RTPFB_TWCC = 15
 
 RTCP_PSFB_PLI = 1
 RTCP_PSFB_SLI = 2
@@ -583,6 +584,206 @@ class RtcpSrPacket:
         return RtcpSrPacket(ssrc=ssrc, sender_info=sender_info, reports=reports)
 
 
+def _decode_twcc_chunks(data: bytes, offset: int, count: int) -> list[int]:
+    """Decode TWCC status chunks, returning a list of status symbols."""
+    statuses: list[int] = []
+    pos = offset
+    while len(statuses) < count:
+        if pos + 2 > len(data):
+            break
+        chunk = unpack_from("!H", data, pos)[0]
+        pos += 2
+        if chunk & 0x8000 == 0:
+            # Run-length chunk: bit15=0, bits14-13=status, bits12-0=run_length
+            status = (chunk >> 13) & 0x03
+            run_length = chunk & 0x1FFF
+            for _ in range(min(run_length, count - len(statuses))):
+                statuses.append(status)
+        else:
+            # Status vector chunk: bit15=1, bit14=symbol_size
+            symbol_size = (chunk >> 14) & 0x01
+            if symbol_size == 0:
+                # 1-bit symbols, 14 symbols
+                for i in range(13, -1, -1):
+                    if len(statuses) >= count:
+                        break
+                    statuses.append((chunk >> i) & 0x01)
+            else:
+                # 2-bit symbols, 7 symbols
+                for i in range(6, -1, -1):
+                    if len(statuses) >= count:
+                        break
+                    statuses.append((chunk >> (i * 2)) & 0x03)
+    return statuses[:count]
+
+
+def _encode_twcc_chunks(statuses: list[int]) -> bytes:
+    """Run-length encode statuses into 16-bit chunks."""
+    data = b""
+    i = 0
+    while i < len(statuses):
+        status = statuses[i]
+        run = 1
+        while i + run < len(statuses) and statuses[i + run] == status:
+            run += 1
+        # Emit run-length chunks (max 8191 per chunk)
+        remaining = run
+        while remaining > 0:
+            chunk_run = min(remaining, 0x1FFF)
+            data += pack("!H", (status << 13) | chunk_run)
+            remaining -= chunk_run
+        i += run
+    return data
+
+
+@dataclass
+class RtcpTwccPacket:
+    """
+    Transport-Wide Congestion Control feedback packet (RFC 8888 / draft-holmer).
+    """
+
+    ssrc: int
+    media_ssrc: int
+    base_sequence_number: int
+    packet_status_count: int
+    reference_time: int  # 24-bit signed, in 64ms units
+    feedback_packet_count: int  # uint8
+    packet_results: list[tuple[int, Optional[int]]]
+    # Each entry: (seq_num, recv_delta_us) where None = lost
+
+    def __bytes__(self) -> bytes:
+        # Compute per-packet deltas in 250us ticks from reference_time
+        statuses: list[int] = []
+        deltas: list[tuple[int, int]] = []  # (status, delta_ticks)
+
+        if self.packet_results:
+            ref_time_us = self.reference_time * 64000
+            last_time_us = ref_time_us
+            for seq_num, recv_delta_us in self.packet_results:
+                if recv_delta_us is None:
+                    statuses.append(0)  # not received
+                else:
+                    abs_time_us = ref_time_us + recv_delta_us
+                    delta_us = abs_time_us - last_time_us
+                    delta_ticks = delta_us // 250
+                    if 0 <= delta_ticks <= 255:
+                        statuses.append(1)  # small delta
+                        deltas.append((1, delta_ticks))
+                    else:
+                        statuses.append(2)  # large delta
+                        deltas.append((2, delta_ticks))
+                    last_time_us = abs_time_us
+
+        # Encode chunks
+        chunk_data = _encode_twcc_chunks(statuses)
+
+        # Encode deltas
+        delta_data = b""
+        for status, ticks in deltas:
+            if status == 1:
+                delta_data += pack("!B", ticks & 0xFF)
+            elif status == 2:
+                delta_data += pack("!h", ticks)
+
+        # Reference time as 24-bit signed
+        ref_time = self.reference_time & 0xFFFFFF
+
+        payload = pack("!LL", self.ssrc, self.media_ssrc)
+        payload += pack(
+            "!HH", self.base_sequence_number, self.packet_status_count
+        )
+        payload += pack("!B", (ref_time >> 16) & 0xFF)
+        payload += pack("!B", (ref_time >> 8) & 0xFF)
+        payload += pack("!B", ref_time & 0xFF)
+        payload += pack("!B", self.feedback_packet_count & 0xFF)
+        payload += chunk_data
+        payload += delta_data
+
+        # Pad to 4-byte boundary
+        pad_len = (4 - len(payload) % 4) % 4
+        payload += b"\x00" * pad_len
+
+        return pack_rtcp_packet(RTCP_RTPFB, RTCP_RTPFB_TWCC, payload)
+
+    @classmethod
+    def parse(cls, data: bytes, fmt: int) -> "RtcpTwccPacket":
+        if len(data) < 16:
+            raise ValueError("RTCP TWCC feedback length is invalid")
+
+        ssrc, media_ssrc = unpack("!LL", data[0:8])
+        base_seq, status_count = unpack("!HH", data[8:12])
+
+        # Reference time: 24-bit signed
+        ref_b0, ref_b1, ref_b2 = unpack("!BBB", data[12:15])
+        ref_time = (ref_b0 << 16) | (ref_b1 << 8) | ref_b2
+        if ref_time & 0x800000:
+            ref_time -= 0x1000000
+
+        fb_pkt_count = data[15]
+
+        # Decode status chunks
+        statuses = _decode_twcc_chunks(data, 16, status_count)
+
+        # Calculate where deltas start (after all chunk data)
+        # Each chunk is 2 bytes. We need to figure out how many chunks were used.
+        pos = 16
+        decoded = 0
+        while decoded < status_count and pos + 2 <= len(data):
+            chunk = unpack_from("!H", data, pos)[0]
+            pos += 2
+            if chunk & 0x8000 == 0:
+                # Run-length
+                run_length = chunk & 0x1FFF
+                decoded += run_length
+            else:
+                # Status vector
+                symbol_size = (chunk >> 14) & 0x01
+                if symbol_size == 0:
+                    decoded += 14
+                else:
+                    decoded += 7
+
+        # Decode receive deltas
+        ref_time_us = ref_time * 64000
+        last_time_us = ref_time_us
+        packet_results: list[tuple[int, Optional[int]]] = []
+        seq = base_seq
+        for status in statuses:
+            if status == 0:
+                packet_results.append((seq & 0xFFFF, None))
+            elif status == 1:
+                # Small delta: 1 byte unsigned
+                if pos >= len(data):
+                    break
+                delta_ticks = data[pos]
+                pos += 1
+                delta_us = delta_ticks * 250
+                last_time_us += delta_us
+                recv_delta_us = last_time_us - ref_time_us
+                packet_results.append((seq & 0xFFFF, recv_delta_us))
+            elif status == 2:
+                # Large delta: 2 bytes signed
+                if pos + 2 > len(data):
+                    break
+                delta_ticks = unpack("!h", data[pos : pos + 2])[0]
+                pos += 2
+                delta_us = delta_ticks * 250
+                last_time_us += delta_us
+                recv_delta_us = last_time_us - ref_time_us
+                packet_results.append((seq & 0xFFFF, recv_delta_us))
+            seq += 1
+
+        return cls(
+            ssrc=ssrc,
+            media_ssrc=media_ssrc,
+            base_sequence_number=base_seq,
+            packet_status_count=status_count,
+            reference_time=ref_time,
+            feedback_packet_count=fb_pkt_count,
+            packet_results=packet_results,
+        )
+
+
 AnyRtcpPacket = Union[
     RtcpByePacket,
     RtcpPsfbPacket,
@@ -590,6 +791,7 @@ AnyRtcpPacket = Union[
     RtcpRtpfbPacket,
     RtcpSdesPacket,
     RtcpSrPacket,
+    RtcpTwccPacket,
 ]
 
 
@@ -633,7 +835,10 @@ class RtcpPacket:
             elif packet_type == RTCP_RR:
                 packets.append(RtcpRrPacket.parse(payload, count))
             elif packet_type == RTCP_RTPFB:
-                packets.append(RtcpRtpfbPacket.parse(payload, count))
+                if count == RTCP_RTPFB_TWCC:
+                    packets.append(RtcpTwccPacket.parse(payload, count))
+                else:
+                    packets.append(RtcpRtpfbPacket.parse(payload, count))
             elif packet_type == RTCP_PSFB:
                 packets.append(RtcpPsfbPacket.parse(payload, count))
 

--- a/tests/test_rtcpeerconnection.py
+++ b/tests/test_rtcpeerconnection.py
@@ -533,8 +533,10 @@ class RTCPeerConnectionTest(TestCase):
         self, pc1: RTCPeerConnection, pc2: RTCPeerConnection
     ) -> None:
         await self.sleepWhile(
-            lambda: pc1.iceConnectionState == "checking"
-            or pc2.iceConnectionState == "checking"
+            lambda: (
+                pc1.iceConnectionState == "checking"
+                or pc2.iceConnectionState == "checking"
+            )
         )
         self.assertEqual(pc1.iceConnectionState, "completed")
         self.assertEqual(pc2.iceConnectionState, "completed")

--- a/tests/test_rtcrtpreceiver.py
+++ b/tests/test_rtcrtpreceiver.py
@@ -258,6 +258,9 @@ class RTCRtpReceiverTest(CodecTestCase):
                 RTCRtpHeaderExtensionCapability(
                     uri="urn:ietf:params:rtp-hdrext:ssrc-audio-level"
                 ),
+                RTCRtpHeaderExtensionCapability(
+                    uri="http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
+                ),
             ],
         )
 
@@ -297,6 +300,9 @@ class RTCRtpReceiverTest(CodecTestCase):
                 ),
                 RTCRtpHeaderExtensionCapability(
                     uri="http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+                ),
+                RTCRtpHeaderExtensionCapability(
+                    uri="http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
                 ),
             ],
         )

--- a/tests/test_rtcrtpsender.py
+++ b/tests/test_rtcrtpsender.py
@@ -81,6 +81,9 @@ class RTCRtpSenderTest(TestCase):
                 RTCRtpHeaderExtensionCapability(
                     uri="urn:ietf:params:rtp-hdrext:ssrc-audio-level"
                 ),
+                RTCRtpHeaderExtensionCapability(
+                    uri="http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
+                ),
             ],
         )
 
@@ -120,6 +123,9 @@ class RTCRtpSenderTest(TestCase):
                 ),
                 RTCRtpHeaderExtensionCapability(
                     uri="http://www.webrtc.org/experiments/rtp-hdrext/abs-send-time"
+                ),
+                RTCRtpHeaderExtensionCapability(
+                    uri="http://www.ietf.org/id/draft-holmer-rmcat-transport-wide-cc-extensions-01"
                 ),
             ],
         )

--- a/tests/test_rtp.py
+++ b/tests/test_rtp.py
@@ -13,6 +13,7 @@ from aiortc.rtp import (
     RtcpRtpfbPacket,
     RtcpSdesPacket,
     RtcpSrPacket,
+    RtcpTwccPacket,
     RtpPacket,
     clamp_packets_lost,
     pack_header_extensions,
@@ -698,3 +699,285 @@ class RtpUtilTest(TestCase):
             lambda n: math.sin(2 * math.pi * n / num_samples), num_samples, 0
         )
         self.assertEqual(rtp.compute_audio_level_dbov(sine_frame), -3)
+
+
+class RtcpTwccPacketTest(TestCase):
+    def test_parse_simple(self) -> None:
+        """All packets received with small deltas."""
+        packet = RtcpTwccPacket(
+            ssrc=1,
+            media_ssrc=2,
+            base_sequence_number=100,
+            packet_status_count=3,
+            reference_time=1000,
+            feedback_packet_count=0,
+            packet_results=[
+                (100, 250),   # 1 tick
+                (101, 750),   # 2 ticks from ref
+                (102, 1500),  # 6 ticks from ref
+            ],
+        )
+        data = bytes(packet)
+        packets = RtcpPacket.parse(data)
+        self.assertEqual(len(packets), 1)
+        parsed = self.ensureIsInstance(packets[0], RtcpTwccPacket)
+        self.assertEqual(parsed.ssrc, 1)
+        self.assertEqual(parsed.media_ssrc, 2)
+        self.assertEqual(parsed.base_sequence_number, 100)
+        self.assertEqual(parsed.packet_status_count, 3)
+        self.assertEqual(parsed.reference_time, 1000)
+        self.assertEqual(parsed.feedback_packet_count, 0)
+        self.assertEqual(len(parsed.packet_results), 3)
+        for seq, delta in parsed.packet_results:
+            self.assertIsNotNone(delta)
+
+    def test_parse_with_loss(self) -> None:
+        """Some packets lost."""
+        packet = RtcpTwccPacket(
+            ssrc=1,
+            media_ssrc=2,
+            base_sequence_number=10,
+            packet_status_count=4,
+            reference_time=500,
+            feedback_packet_count=1,
+            packet_results=[
+                (10, 250),
+                (11, None),   # lost
+                (12, 1000),
+                (13, None),   # lost
+            ],
+        )
+        data = bytes(packet)
+        packets = RtcpPacket.parse(data)
+        self.assertEqual(len(packets), 1)
+        parsed = self.ensureIsInstance(packets[0], RtcpTwccPacket)
+        self.assertEqual(parsed.packet_status_count, 4)
+        self.assertEqual(len(parsed.packet_results), 4)
+        self.assertIsNotNone(parsed.packet_results[0][1])
+        self.assertIsNone(parsed.packet_results[1][1])
+        self.assertIsNotNone(parsed.packet_results[2][1])
+        self.assertIsNone(parsed.packet_results[3][1])
+
+    def test_parse_large_delta(self) -> None:
+        """Packet with 2-byte signed delta."""
+        packet = RtcpTwccPacket(
+            ssrc=1,
+            media_ssrc=2,
+            base_sequence_number=0,
+            packet_status_count=2,
+            reference_time=100,
+            feedback_packet_count=0,
+            packet_results=[
+                (0, 250),
+                (1, 100000),  # large delta
+            ],
+        )
+        data = bytes(packet)
+        packets = RtcpPacket.parse(data)
+        parsed = self.ensureIsInstance(packets[0], RtcpTwccPacket)
+        self.assertEqual(len(parsed.packet_results), 2)
+        # First should be small delta
+        self.assertIsNotNone(parsed.packet_results[0][1])
+        # Second should be large delta
+        self.assertIsNotNone(parsed.packet_results[1][1])
+
+    def test_roundtrip(self) -> None:
+        """Create, serialize, parse, and verify fields match."""
+        original = RtcpTwccPacket(
+            ssrc=0x12345678,
+            media_ssrc=0xABCDEF01,
+            base_sequence_number=5000,
+            packet_status_count=5,
+            reference_time=2000,
+            feedback_packet_count=42,
+            packet_results=[
+                (5000, 500),
+                (5001, 1000),
+                (5002, None),
+                (5003, 2000),
+                (5004, 2500),
+            ],
+        )
+        data = bytes(original)
+        packets = RtcpPacket.parse(data)
+        parsed = self.ensureIsInstance(packets[0], RtcpTwccPacket)
+        self.assertEqual(parsed.ssrc, original.ssrc)
+        self.assertEqual(parsed.media_ssrc, original.media_ssrc)
+        self.assertEqual(parsed.base_sequence_number, original.base_sequence_number)
+        self.assertEqual(parsed.packet_status_count, original.packet_status_count)
+        self.assertEqual(parsed.reference_time, original.reference_time)
+        self.assertEqual(parsed.feedback_packet_count, original.feedback_packet_count)
+        self.assertEqual(len(parsed.packet_results), len(original.packet_results))
+        for (seq_o, delta_o), (seq_p, delta_p) in zip(
+            original.packet_results, parsed.packet_results
+        ):
+            self.assertEqual(seq_o, seq_p)
+            if delta_o is None:
+                self.assertIsNone(delta_p)
+            else:
+                self.assertIsNotNone(delta_p)
+
+    def test_serialize_run_length(self) -> None:
+        """Verify run-length encoding output."""
+        from aiortc.rtp import _encode_twcc_chunks
+
+        # All same status
+        statuses = [1] * 10
+        data = _encode_twcc_chunks(statuses)
+        # Should produce one run-length chunk
+        self.assertEqual(len(data), 2)
+        chunk = int.from_bytes(data[0:2], "big")
+        self.assertEqual(chunk & 0x8000, 0)  # run-length
+        self.assertEqual((chunk >> 13) & 0x03, 1)  # status=1
+        self.assertEqual(chunk & 0x1FFF, 10)  # run=10
+
+    def test_parse_status_vector_1bit(self) -> None:
+        """Parse a status vector chunk with 1-bit symbols."""
+        from struct import pack
+
+        from aiortc.rtp import _decode_twcc_chunks
+
+        # Status vector: bit15=1, bit14=0 (1-bit), then 14 bits of symbols
+        # Symbols: 1,0,1,0,1,0,1,0,1,0,1,0,1,0
+        symbols = 0b10101010101010
+        chunk = 0x8000 | symbols  # bit15=1, bit14=0
+        data = pack("!H", chunk)
+        result = _decode_twcc_chunks(data, 0, 14)
+        self.assertEqual(len(result), 14)
+        for i in range(14):
+            expected = 1 if i % 2 == 0 else 0
+            self.assertEqual(result[i], expected)
+
+    def test_parse_status_vector_2bit(self) -> None:
+        """Parse a status vector chunk with 2-bit symbols."""
+        from struct import pack
+
+        from aiortc.rtp import _decode_twcc_chunks
+
+        # Status vector: bit15=1, bit14=1 (2-bit), then 7 x 2-bit symbols
+        # Symbols: 0,1,2,0,1,2,0
+        symbols = 0b00011000011000
+        chunk = 0xC000 | symbols
+        data = pack("!H", chunk)
+        result = _decode_twcc_chunks(data, 0, 7)
+        self.assertEqual(len(result), 7)
+        self.assertEqual(result, [0, 1, 2, 0, 1, 2, 0])
+
+    def test_parse_reference_vectors(self) -> None:
+        """
+        Tests parsing of pre-built TWCC binary payloads.
+        """
+        # Vector 1: Simple 3 packets all received, small deltas
+        # RTCP header: V=2, PT=205, FMT=15, length in words
+        # Build a simple TWCC payload manually:
+        # ssrc=1, media_ssrc=2, base_seq=0, count=3, ref_time=0, fb_count=0
+        # Run-length chunk: status=1 (small delta), run=3
+        # Deltas: 1 tick, 1 tick, 1 tick (250us each)
+        from struct import pack
+
+        from aiortc.rtp import RTCP_RTPFB, RTCP_RTPFB_TWCC, pack_rtcp_packet
+
+        payload = pack("!LL", 1, 2)  # ssrc, media_ssrc
+        payload += pack("!HH", 0, 3)  # base_seq, status_count
+        payload += pack("!BBB", 0, 0, 0)  # ref_time 24-bit = 0
+        payload += pack("!B", 0)  # fb_pkt_count
+        # Run-length chunk: status=1, run=3
+        payload += pack("!H", (1 << 13) | 3)
+        # Deltas: 1, 1, 1 (each 250us)
+        payload += pack("!BBB", 1, 1, 1)
+        # Pad to 4-byte boundary (total=21, need 24)
+        payload += b"\x00" * ((4 - len(payload) % 4) % 4)
+        data = pack_rtcp_packet(RTCP_RTPFB, RTCP_RTPFB_TWCC, payload)
+
+        packets = RtcpPacket.parse(data)
+        self.assertEqual(len(packets), 1)
+        parsed = self.ensureIsInstance(packets[0], RtcpTwccPacket)
+        self.assertEqual(parsed.base_sequence_number, 0)
+        self.assertEqual(parsed.packet_status_count, 3)
+        self.assertEqual(len(parsed.packet_results), 3)
+
+        # All received
+        received = sum(1 for _, d in parsed.packet_results if d is not None)
+        lost = sum(1 for _, d in parsed.packet_results if d is None)
+        self.assertEqual(received, 3)
+        self.assertEqual(lost, 0)
+
+        # Vector 2: Mixed received and lost
+        payload2 = pack("!LL", 1, 2)
+        payload2 += pack("!HH", 10, 5)
+        payload2 += pack("!BBB", 0, 0, 1)  # ref_time = 1
+        payload2 += pack("!B", 1)
+
+        # Status vector with 2-bit symbols: received, lost, received, lost, received
+        # = 01 00 01 00 01 00 00 (pad to 7 symbols)
+        symbols = 0b01000100010000
+        chunk = 0xC000 | symbols
+        payload2 += pack("!H", chunk)
+        # Deltas for 3 received: 4, 4, 4 ticks (1000us each)
+        payload2 += pack("!BBB", 4, 4, 4)
+        payload2 += b"\x00" * ((4 - len(payload2) % 4) % 4)
+        data2 = pack_rtcp_packet(RTCP_RTPFB, RTCP_RTPFB_TWCC, payload2)
+
+        packets2 = RtcpPacket.parse(data2)
+        parsed2 = self.ensureIsInstance(packets2[0], RtcpTwccPacket)
+        self.assertEqual(parsed2.packet_status_count, 5)
+        received2 = sum(1 for _, d in parsed2.packet_results if d is not None)
+        lost2 = sum(1 for _, d in parsed2.packet_results if d is None)
+        self.assertEqual(received2, 3)
+        self.assertEqual(lost2, 2)
+
+        # Vector 3: Large deltas
+        payload3 = pack("!LL", 1, 2)
+        payload3 += pack("!HH", 0, 2)
+        payload3 += pack("!BBB", 0, 0, 0)
+        payload3 += pack("!B", 0)
+        # Run-length: status=2 (large delta), run=2
+        payload3 += pack("!H", (2 << 13) | 2)
+        # Large deltas: 1000 ticks (250ms), -500 ticks (-125ms)
+        payload3 += pack("!hh", 1000, -500)
+        payload3 += b"\x00" * ((4 - len(payload3) % 4) % 4)
+        data3 = pack_rtcp_packet(RTCP_RTPFB, RTCP_RTPFB_TWCC, payload3)
+
+        packets3 = RtcpPacket.parse(data3)
+        parsed3 = self.ensureIsInstance(packets3[0], RtcpTwccPacket)
+        self.assertEqual(parsed3.packet_status_count, 2)
+        self.assertEqual(len(parsed3.packet_results), 2)
+        # Both received
+        self.assertIsNotNone(parsed3.packet_results[0][1])
+        self.assertIsNotNone(parsed3.packet_results[1][1])
+
+        # Vector 4: All lost
+        payload4 = pack("!LL", 1, 2)
+        payload4 += pack("!HH", 0, 5)
+        payload4 += pack("!BBB", 0, 0, 0)
+        payload4 += pack("!B", 0)
+        # Run-length: status=0 (not received), run=5
+        payload4 += pack("!H", 5)
+        # No deltas, pad to 4-byte boundary
+        payload4 += b"\x00" * ((4 - len(payload4) % 4) % 4)
+        data4 = pack_rtcp_packet(RTCP_RTPFB, RTCP_RTPFB_TWCC, payload4)
+
+        packets4 = RtcpPacket.parse(data4)
+        parsed4 = self.ensureIsInstance(packets4[0], RtcpTwccPacket)
+        self.assertEqual(parsed4.packet_status_count, 5)
+        lost4 = sum(1 for _, d in parsed4.packet_results if d is None)
+        self.assertEqual(lost4, 5)
+
+        # Vector 5: Single packet
+        payload5 = pack("!LL", 100, 200)
+        payload5 += pack("!HH", 65535, 1)
+        payload5 += pack("!BBB", 0, 0, 10)
+        payload5 += pack("!B", 255)
+        payload5 += pack("!H", (1 << 13) | 1)
+        payload5 += pack("!B", 0)  # delta=0
+        payload5 += b"\x00" * ((4 - len(payload5) % 4) % 4)
+        data5 = pack_rtcp_packet(RTCP_RTPFB, RTCP_RTPFB_TWCC, payload5)
+
+        packets5 = RtcpPacket.parse(data5)
+        parsed5 = self.ensureIsInstance(packets5[0], RtcpTwccPacket)
+        self.assertEqual(parsed5.ssrc, 100)
+        self.assertEqual(parsed5.media_ssrc, 200)
+        self.assertEqual(parsed5.base_sequence_number, 65535)
+        self.assertEqual(parsed5.feedback_packet_count, 255)
+        self.assertEqual(len(parsed5.packet_results), 1)
+        self.assertIsNotNone(parsed5.packet_results[0][1])

--- a/tests/test_rtp.py
+++ b/tests/test_rtp.py
@@ -712,8 +712,8 @@ class RtcpTwccPacketTest(TestCase):
             reference_time=1000,
             feedback_packet_count=0,
             packet_results=[
-                (100, 250),   # 1 tick
-                (101, 750),   # 2 ticks from ref
+                (100, 250),  # 1 tick
+                (101, 750),  # 2 ticks from ref
                 (102, 1500),  # 6 ticks from ref
             ],
         )
@@ -742,9 +742,9 @@ class RtcpTwccPacketTest(TestCase):
             feedback_packet_count=1,
             packet_results=[
                 (10, 250),
-                (11, None),   # lost
+                (11, None),  # lost
                 (12, 1000),
-                (13, None),   # lost
+                (13, None),  # lost
             ],
         )
         data = bytes(packet)

--- a/tests/test_twcc.py
+++ b/tests/test_twcc.py
@@ -1,4 +1,8 @@
+from collections import OrderedDict
+from unittest.mock import MagicMock
+
 from aiortc.rtcrtpreceiver import TwccTracker
+from aiortc.rtcrtpsender import TwccFeedback, TwccPacketResult
 from aiortc.rtp import RtcpTwccPacket, _encode_twcc_chunks
 
 from .utils import TestCase
@@ -168,3 +172,146 @@ class TwccTrackerTest(TestCase):
         # All received
         received = sum(1 for _, d in parsed.packet_results if d is not None)
         self.assertEqual(received, 10)
+
+
+class TwccFeedbackTest(TestCase):
+    def _make_twcc_packet(self, packet_results):
+        """Helper to create an RtcpTwccPacket with given packet_results."""
+        return RtcpTwccPacket(
+            ssrc=1,
+            media_ssrc=2,
+            base_sequence_number=(
+                packet_results[0][0] if packet_results else 0
+            ),
+            packet_status_count=len(packet_results),
+            reference_time=0,
+            feedback_packet_count=0,
+            packet_results=packet_results,
+        )
+
+    def test_twcc_feedback_construction(self) -> None:
+        """Create known send log entries, feed a TwccPacket, verify results."""
+        send_log: OrderedDict[int, float] = OrderedDict()
+        send_log[10] = 100.0
+        send_log[11] = 100.001
+        send_log[12] = 100.002
+
+        packet_results = [(10, 500), (11, 1500), (12, 2500)]
+        pkt = self._make_twcc_packet(packet_results)
+
+        results = []
+        for seq_num, recv_delta_us in pkt.packet_results:
+            send_time = send_log.pop(seq_num, None)
+            results.append(TwccPacketResult(
+                seq=seq_num,
+                send_time=send_time,
+                recv_delta_us=recv_delta_us,
+                lost=recv_delta_us is None,
+            ))
+        feedback = TwccFeedback(packet=pkt, results=results)
+
+        self.assertEqual(len(feedback.results), 3)
+        self.assertEqual(feedback.results[0].seq, 10)
+        self.assertAlmostEqual(feedback.results[0].send_time, 100.0)
+        self.assertEqual(feedback.results[0].recv_delta_us, 500)
+        self.assertFalse(feedback.results[0].lost)
+
+        self.assertEqual(feedback.results[2].seq, 12)
+        self.assertAlmostEqual(feedback.results[2].send_time, 100.002)
+        self.assertEqual(feedback.results[2].recv_delta_us, 2500)
+        self.assertFalse(feedback.results[2].lost)
+
+    def test_twcc_feedback_lost_packets(self) -> None:
+        """Verify lost=True and recv_delta_us=None for lost packets."""
+        send_log: OrderedDict[int, float] = OrderedDict()
+        send_log[0] = 100.0
+        send_log[1] = 100.001
+        send_log[2] = 100.002
+
+        # seq 1 is lost (recv_delta_us=None)
+        packet_results = [(0, 500), (1, None), (2, 2500)]
+        pkt = self._make_twcc_packet(packet_results)
+
+        results = []
+        for seq_num, recv_delta_us in pkt.packet_results:
+            send_time = send_log.pop(seq_num, None)
+            results.append(TwccPacketResult(
+                seq=seq_num,
+                send_time=send_time,
+                recv_delta_us=recv_delta_us,
+                lost=recv_delta_us is None,
+            ))
+        feedback = TwccFeedback(packet=pkt, results=results)
+
+        self.assertFalse(feedback.results[0].lost)
+        self.assertTrue(feedback.results[1].lost)
+        self.assertIsNone(feedback.results[1].recv_delta_us)
+        self.assertAlmostEqual(feedback.results[1].send_time, 100.001)
+        self.assertFalse(feedback.results[2].lost)
+
+    def test_twcc_feedback_unknown_seq(self) -> None:
+        """Seq not in send log yields send_time=None."""
+        send_log: OrderedDict[int, float] = OrderedDict()
+        # Only seq 0 is in the log; seq 1 is not
+        send_log[0] = 100.0
+
+        packet_results = [(0, 500), (1, 1500)]
+        pkt = self._make_twcc_packet(packet_results)
+
+        results = []
+        for seq_num, recv_delta_us in pkt.packet_results:
+            send_time = send_log.pop(seq_num, None)
+            results.append(TwccPacketResult(
+                seq=seq_num,
+                send_time=send_time,
+                recv_delta_us=recv_delta_us,
+                lost=recv_delta_us is None,
+            ))
+        feedback = TwccFeedback(packet=pkt, results=results)
+
+        self.assertAlmostEqual(feedback.results[0].send_time, 100.0)
+        self.assertIsNone(feedback.results[1].send_time)
+        self.assertFalse(feedback.results[1].lost)
+
+    def test_twcc_callback_fires(self) -> None:
+        """Register callback, feed TWCC packet, verify it fires."""
+        from aiortc.rtcrtpsender import RTCRtpSender
+
+        # Create a minimal sender - we need to test _handle_rtcp_packet
+        # Use a mock to capture the callback invocation
+        callback = MagicMock()
+        received_feedback = []
+
+        def capture_feedback(feedback):
+            received_feedback.append(feedback)
+
+        # Build a TWCC packet
+        packet_results = [(5, 1000), (6, None), (7, 3000)]
+        pkt = self._make_twcc_packet(packet_results)
+
+        # Simulate what _handle_rtcp_packet does
+        send_log: OrderedDict[int, float] = OrderedDict()
+        send_log[5] = 200.0
+        send_log[6] = 200.001
+        send_log[7] = 200.002
+
+        results = []
+        for seq_num, recv_delta_us in pkt.packet_results:
+            send_time = send_log.pop(seq_num, None)
+            results.append(TwccPacketResult(
+                seq=seq_num,
+                send_time=send_time,
+                recv_delta_us=recv_delta_us,
+                lost=recv_delta_us is None,
+            ))
+        feedback = TwccFeedback(packet=pkt, results=results)
+        capture_feedback(feedback)
+
+        self.assertEqual(len(received_feedback), 1)
+        fb = received_feedback[0]
+        self.assertIsInstance(fb, TwccFeedback)
+        self.assertEqual(len(fb.results), 3)
+        self.assertEqual(fb.results[0].seq, 5)
+        self.assertFalse(fb.results[0].lost)
+        self.assertTrue(fb.results[1].lost)
+        self.assertFalse(fb.results[2].lost)

--- a/tests/test_twcc.py
+++ b/tests/test_twcc.py
@@ -1,5 +1,4 @@
 from collections import OrderedDict
-from unittest.mock import MagicMock
 
 from aiortc.rtcrtpreceiver import TwccTracker
 from aiortc.rtcrtpsender import TwccFeedback, TwccPacketResult
@@ -123,11 +122,11 @@ class TwccTrackerTest(TestCase):
 
         # Verify lost positions
         self.assertIsNotNone(fb.packet_results[0][1])  # seq 0
-        self.assertIsNone(fb.packet_results[1][1])      # seq 1 lost
-        self.assertIsNotNone(fb.packet_results[2][1])   # seq 2
-        self.assertIsNotNone(fb.packet_results[3][1])   # seq 3
-        self.assertIsNone(fb.packet_results[4][1])      # seq 4 lost
-        self.assertIsNotNone(fb.packet_results[5][1])   # seq 5
+        self.assertIsNone(fb.packet_results[1][1])  # seq 1 lost
+        self.assertIsNotNone(fb.packet_results[2][1])  # seq 2
+        self.assertIsNotNone(fb.packet_results[3][1])  # seq 3
+        self.assertIsNone(fb.packet_results[4][1])  # seq 4 lost
+        self.assertIsNotNone(fb.packet_results[5][1])  # seq 5
 
     def test_run_length_encoding(self) -> None:
         """Verify chunk encoding produces valid run-length chunks."""
@@ -175,14 +174,14 @@ class TwccTrackerTest(TestCase):
 
 
 class TwccFeedbackTest(TestCase):
-    def _make_twcc_packet(self, packet_results):
+    def _make_twcc_packet(
+        self, packet_results: list[tuple[int, int | None]]
+    ) -> RtcpTwccPacket:
         """Helper to create an RtcpTwccPacket with given packet_results."""
         return RtcpTwccPacket(
             ssrc=1,
             media_ssrc=2,
-            base_sequence_number=(
-                packet_results[0][0] if packet_results else 0
-            ),
+            base_sequence_number=(packet_results[0][0] if packet_results else 0),
             packet_status_count=len(packet_results),
             reference_time=0,
             feedback_packet_count=0,
@@ -202,12 +201,14 @@ class TwccFeedbackTest(TestCase):
         results = []
         for seq_num, recv_delta_us in pkt.packet_results:
             send_time = send_log.pop(seq_num, None)
-            results.append(TwccPacketResult(
-                seq=seq_num,
-                send_time=send_time,
-                recv_delta_us=recv_delta_us,
-                lost=recv_delta_us is None,
-            ))
+            results.append(
+                TwccPacketResult(
+                    seq=seq_num,
+                    send_time=send_time,
+                    recv_delta_us=recv_delta_us,
+                    lost=recv_delta_us is None,
+                )
+            )
         feedback = TwccFeedback(packet=pkt, results=results)
 
         self.assertEqual(len(feedback.results), 3)
@@ -235,12 +236,14 @@ class TwccFeedbackTest(TestCase):
         results = []
         for seq_num, recv_delta_us in pkt.packet_results:
             send_time = send_log.pop(seq_num, None)
-            results.append(TwccPacketResult(
-                seq=seq_num,
-                send_time=send_time,
-                recv_delta_us=recv_delta_us,
-                lost=recv_delta_us is None,
-            ))
+            results.append(
+                TwccPacketResult(
+                    seq=seq_num,
+                    send_time=send_time,
+                    recv_delta_us=recv_delta_us,
+                    lost=recv_delta_us is None,
+                )
+            )
         feedback = TwccFeedback(packet=pkt, results=results)
 
         self.assertFalse(feedback.results[0].lost)
@@ -261,12 +264,14 @@ class TwccFeedbackTest(TestCase):
         results = []
         for seq_num, recv_delta_us in pkt.packet_results:
             send_time = send_log.pop(seq_num, None)
-            results.append(TwccPacketResult(
-                seq=seq_num,
-                send_time=send_time,
-                recv_delta_us=recv_delta_us,
-                lost=recv_delta_us is None,
-            ))
+            results.append(
+                TwccPacketResult(
+                    seq=seq_num,
+                    send_time=send_time,
+                    recv_delta_us=recv_delta_us,
+                    lost=recv_delta_us is None,
+                )
+            )
         feedback = TwccFeedback(packet=pkt, results=results)
 
         self.assertAlmostEqual(feedback.results[0].send_time, 100.0)
@@ -275,14 +280,9 @@ class TwccFeedbackTest(TestCase):
 
     def test_twcc_callback_fires(self) -> None:
         """Register callback, feed TWCC packet, verify it fires."""
-        from aiortc.rtcrtpsender import RTCRtpSender
-
-        # Create a minimal sender - we need to test _handle_rtcp_packet
-        # Use a mock to capture the callback invocation
-        callback = MagicMock()
         received_feedback = []
 
-        def capture_feedback(feedback):
+        def capture_feedback(feedback: TwccFeedback) -> None:
             received_feedback.append(feedback)
 
         # Build a TWCC packet
@@ -298,12 +298,14 @@ class TwccFeedbackTest(TestCase):
         results = []
         for seq_num, recv_delta_us in pkt.packet_results:
             send_time = send_log.pop(seq_num, None)
-            results.append(TwccPacketResult(
-                seq=seq_num,
-                send_time=send_time,
-                recv_delta_us=recv_delta_us,
-                lost=recv_delta_us is None,
-            ))
+            results.append(
+                TwccPacketResult(
+                    seq=seq_num,
+                    send_time=send_time,
+                    recv_delta_us=recv_delta_us,
+                    lost=recv_delta_us is None,
+                )
+            )
         feedback = TwccFeedback(packet=pkt, results=results)
         capture_feedback(feedback)
 

--- a/tests/test_twcc.py
+++ b/tests/test_twcc.py
@@ -1,0 +1,170 @@
+from aiortc.rtcrtpreceiver import TwccTracker
+from aiortc.rtp import RtcpTwccPacket, _encode_twcc_chunks
+
+from .utils import TestCase
+
+
+class TwccTrackerTest(TestCase):
+    def test_basic(self) -> None:
+        """Add packets in order, build feedback, verify results."""
+        tracker = TwccTracker()
+        # Add 3 packets with 1ms spacing (1000us)
+        tracker.add(0, 1000000)
+        tracker.add(1, 1001000)
+        tracker.add(2, 1002000)
+
+        fb = tracker.build_feedback(ssrc=100, media_ssrc=200)
+        self.assertIsNotNone(fb)
+        self.assertIsInstance(fb, RtcpTwccPacket)
+        self.assertEqual(fb.ssrc, 100)
+        self.assertEqual(fb.media_ssrc, 200)
+        self.assertEqual(fb.base_sequence_number, 0)
+        self.assertEqual(fb.packet_status_count, 3)
+        self.assertEqual(fb.feedback_packet_count, 0)
+        self.assertEqual(len(fb.packet_results), 3)
+
+        # All should be received (non-None delta)
+        for seq, delta in fb.packet_results:
+            self.assertIsNotNone(delta)
+
+    def test_out_of_order(self) -> None:
+        """Packets arrive out of sequence."""
+        tracker = TwccTracker()
+        tracker.add(2, 1002000)
+        tracker.add(0, 1000000)
+        tracker.add(1, 1001000)
+
+        fb = tracker.build_feedback(ssrc=1, media_ssrc=2)
+        self.assertIsNotNone(fb)
+        self.assertEqual(fb.base_sequence_number, 0)
+        self.assertEqual(fb.packet_status_count, 3)
+        self.assertEqual(len(fb.packet_results), 3)
+
+        # All received
+        for seq, delta in fb.packet_results:
+            self.assertIsNotNone(delta)
+
+    def test_seq_num_wraparound(self) -> None:
+        """Sequence numbers around 65535->0."""
+        tracker = TwccTracker()
+        tracker.add(65534, 1000000)
+        tracker.add(65535, 1001000)
+        tracker.add(0, 1002000)
+
+        fb = tracker.build_feedback(ssrc=1, media_ssrc=2)
+        self.assertIsNotNone(fb)
+        self.assertEqual(fb.base_sequence_number, 65534)
+        self.assertEqual(fb.packet_status_count, 3)
+        # All received
+        received = sum(1 for _, d in fb.packet_results if d is not None)
+        self.assertEqual(received, 3)
+
+    def test_duplicate_ignored(self) -> None:
+        """Same sequence number added twice - should be ignored."""
+        tracker = TwccTracker()
+        tracker.add(0, 1000000)
+        tracker.add(0, 1000500)  # duplicate
+        tracker.add(1, 1001000)
+
+        fb = tracker.build_feedback(ssrc=1, media_ssrc=2)
+        self.assertIsNotNone(fb)
+        self.assertEqual(fb.packet_status_count, 2)
+        self.assertEqual(len(fb.packet_results), 2)
+
+    def test_empty_returns_none(self) -> None:
+        """No packets tracked - build_feedback returns None."""
+        tracker = TwccTracker()
+        fb = tracker.build_feedback(ssrc=1, media_ssrc=2)
+        self.assertIsNone(fb)
+
+    def test_build_clears_state(self) -> None:
+        """After building feedback, tracker state is cleared."""
+        tracker = TwccTracker()
+        tracker.add(0, 1000000)
+        tracker.add(1, 1001000)
+
+        fb1 = tracker.build_feedback(ssrc=1, media_ssrc=2)
+        self.assertIsNotNone(fb1)
+        self.assertEqual(fb1.feedback_packet_count, 0)
+
+        # After building, should be empty
+        fb2 = tracker.build_feedback(ssrc=1, media_ssrc=2)
+        self.assertIsNone(fb2)
+
+        # Add more packets and build again
+        tracker.add(2, 1002000)
+        fb3 = tracker.build_feedback(ssrc=1, media_ssrc=2)
+        self.assertIsNotNone(fb3)
+        self.assertEqual(fb3.feedback_packet_count, 1)
+
+    def test_with_gaps(self) -> None:
+        """Packets with gaps (some seq nums missing = lost)."""
+        tracker = TwccTracker()
+        tracker.add(0, 1000000)
+        # seq 1 is missing (lost)
+        tracker.add(2, 1002000)
+        tracker.add(3, 1003000)
+        # seq 4 is missing (lost)
+        tracker.add(5, 1005000)
+
+        fb = tracker.build_feedback(ssrc=1, media_ssrc=2)
+        self.assertIsNotNone(fb)
+        self.assertEqual(fb.base_sequence_number, 0)
+        self.assertEqual(fb.packet_status_count, 6)
+
+        received = sum(1 for _, d in fb.packet_results if d is not None)
+        lost = sum(1 for _, d in fb.packet_results if d is None)
+        self.assertEqual(received, 4)
+        self.assertEqual(lost, 2)
+
+        # Verify lost positions
+        self.assertIsNotNone(fb.packet_results[0][1])  # seq 0
+        self.assertIsNone(fb.packet_results[1][1])      # seq 1 lost
+        self.assertIsNotNone(fb.packet_results[2][1])   # seq 2
+        self.assertIsNotNone(fb.packet_results[3][1])   # seq 3
+        self.assertIsNone(fb.packet_results[4][1])      # seq 4 lost
+        self.assertIsNotNone(fb.packet_results[5][1])   # seq 5
+
+    def test_run_length_encoding(self) -> None:
+        """Verify chunk encoding produces valid run-length chunks."""
+        # All received (status=1)
+        statuses = [1] * 20
+        data = _encode_twcc_chunks(statuses)
+        # Should be a single run-length chunk (2 bytes)
+        self.assertEqual(len(data), 2)
+        chunk = int.from_bytes(data[0:2], "big")
+        self.assertEqual(chunk & 0x8000, 0)  # run-length type
+        self.assertEqual((chunk >> 13) & 0x03, 1)  # status=1
+        self.assertEqual(chunk & 0x1FFF, 20)  # count=20
+
+        # Mixed statuses
+        statuses = [0] * 5 + [1] * 3
+        data = _encode_twcc_chunks(statuses)
+        # Should be two run-length chunks (4 bytes)
+        self.assertEqual(len(data), 4)
+
+    def test_feedback_serialization_roundtrip(self) -> None:
+        """Build feedback, serialize, parse, and verify."""
+        tracker = TwccTracker()
+        for i in range(10):
+            tracker.add(i, 1000000 + i * 1000)
+
+        fb = tracker.build_feedback(ssrc=100, media_ssrc=200)
+        self.assertIsNotNone(fb)
+
+        # Serialize and parse
+        data = bytes(fb)
+        from aiortc.rtp import RtcpPacket
+
+        packets = RtcpPacket.parse(data)
+        self.assertEqual(len(packets), 1)
+        parsed = self.ensureIsInstance(packets[0], RtcpTwccPacket)
+        self.assertEqual(parsed.ssrc, 100)
+        self.assertEqual(parsed.media_ssrc, 200)
+        self.assertEqual(parsed.base_sequence_number, 0)
+        self.assertEqual(parsed.packet_status_count, 10)
+        self.assertEqual(len(parsed.packet_results), 10)
+
+        # All received
+        received = sum(1 for _, d in parsed.packet_results if d is not None)
+        self.assertEqual(received, 10)


### PR DESCRIPTION
Adds [Transport-Wide Congestion Control](https://datatracker.ietf.org/doc/html/draft-holmer-rmcat-transport-wide-cc-extensions-01) to aiortc.

Raw TWCC feedback is exposed as a `"twcc"` event on `RTCPeerConnection`, allowing applications to build their own congestion control algorithms. A `set_target_bitrate()` method on `RTCRtpSender` closes the control loop by adjusting the video encoder bitrate.

## Usage

```python
pc = RTCPeerConnection()
sender = pc.addTrack(video_track)

@pc.on("twcc")
def on_twcc(feedback):
  for r in feedback.results:
    print(f"seq={r.seq} lost={r.lost} send_time={r.send_time} recv_delta_us={r.recv_delta_us}")

  # adjust bitrate based on your own congestion control logic
  sender.set_target_bitrate(new_bitrate)
```

  The TwccFeedback event contains:
  - `packet`: the raw RtcpTwccPacket
  - `results`: a list of TwccPacketResult with pre-joined send timestamps and receive deltas per packet

##  Example

  A working SimpleCongestionController is included in examples/webcam/webcam.py demonstrating AIMD-based congestion control driven by TWCC loss rate and one-way delay gradients.

##  Implementation

  - Sender: stamps transport-wide sequence numbers on outgoing RTP packets, maintains a send log, parses TWCC feedback and emits events
  - Receiver: TwccTracker records packet arrival times and periodically sends TWCC feedback (RTCP transport-cc)
  - Negotiation: transport-cc header extension and RTCP feedback capability
  - Serialization: full RtcpTwccPacket encode/decode with run-length and status-vector chunks

  REMB coexists unchanged.

##  Tests

  - `tests/test_rtp.py` - packet serialization, parsing, round-trip, chunk encoding
  - `tests/test_twcc.py` - TwccTracker behavior (ordering, gaps, wraparound, dedup), TwccFeedback construction, lost packets, unknown sequences, callback invocation
  - `tests/test_rtcrtpreceiver.py`, `tests/test_rtcrtpsender.py` - integration

