### PR TITLE
Reduce keyframe interval for VP8 (3000 -> 30) and H264

### DIFF
--- a/src/aiortc/codecs/h264.py
+++ b/src/aiortc/codecs/h264.py
@@ -274,6 +274,7 @@ class H264Encoder(Encoder):
             self.codec.pix_fmt = "yuv420p"
             self.codec.framerate = fractions.Fraction(MAX_FRAME_RATE, 1)
             self.codec.time_base = fractions.Fraction(1, MAX_FRAME_RATE)
+            self.codec.gop_size = MAX_FRAME_RATE  # ~1s
             self.codec.options = {
                 "level": "31",
                 "tune": "zerolatency",

--- a/src/aiortc/codecs/vpx.py
+++ b/src/aiortc/codecs/vpx.py
@@ -213,7 +213,7 @@ class Vp8Encoder(Encoder):
             self.codec.height = frame.height
             self.codec.bit_rate = self.target_bitrate
             self.codec.pix_fmt = "yuv420p"
-            self.codec.gop_size = 3000  # kf_max_dist
+            self.codec.gop_size = MAX_FRAME_RATE  # kf_max_dist (~1s)
             self.codec.qmin = 2  # rc_min_quantizer
             self.codec.qmax = 56  # rc_max_quantizer
             self.codec.options = {

--- a/tests/test_gop_size.py
+++ b/tests/test_gop_size.py
@@ -1,0 +1,36 @@
+import fractions
+from unittest import TestCase
+
+from av.video.frame import VideoFrame
+
+from aiortc.codecs.h264 import H264Encoder
+from aiortc.codecs.vpx import Vp8Encoder
+
+
+class Vp8GopSizeTest(TestCase):
+    def test_gop_size_is_reasonable(self) -> None:
+        """VP8 gop_size should be <= 60 for timely keyframe insertion."""
+        encoder = Vp8Encoder()
+
+        frame = VideoFrame(width=320, height=240, format="yuv420p")
+        frame.pts = 0
+        frame.time_base = fractions.Fraction(1, 90000)
+        encoder.encode(frame)
+
+        self.assertIsNotNone(encoder.codec)
+        self.assertLessEqual(encoder.codec.gop_size, 60)
+
+
+class H264GopSizeTest(TestCase):
+    def test_gop_size_is_reasonable(self) -> None:
+        """H264 gop_size should be explicitly set to <= 60."""
+        encoder = H264Encoder()
+
+        frame = VideoFrame(width=320, height=240, format="yuv420p")
+        frame.pts = 0
+        frame.time_base = fractions.Fraction(1, 90000)
+        # H264Encoder._encode_frame is a generator
+        list(encoder._encode_frame(frame, force_keyframe=False))
+
+        self.assertIsNotNone(encoder.codec)
+        self.assertLessEqual(encoder.codec.gop_size, 60)


### PR DESCRIPTION
## Summary

- VP8: `gop_size` 3000 → 30 (~1s at 30fps instead of ~100s)
- H264: add explicit `gop_size = 30` (was unset, libx264 default ~250)

## Problem

The VP8 encoder's `gop_size=3000` means natural keyframes only appear every ~100 seconds at 30fps. When packet loss occurs and RTCP PLI is delayed or lost, the receiver cannot recover until the next keyframe — effectively freezing video for up to 100 seconds.

A `gop_size` of 30 (~1 second) ensures timely recovery with minimal impact on encoding efficiency.

## Test plan

- [x] Existing tests pass
- [x] Manual verification: `encoder.codec.gop_size == 30` after encoding a frame

🤖 Generated with [Claude Code](https://claude.com/claude-code)